### PR TITLE
fix: prefix local resume paths with VITE_ROOT_PATH

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -122,20 +122,19 @@ export const envHelpers = {
   },
 
   /**
-   * Get resume PDF path with validation and formatting
-   * Ensures local paths start with /
+   * Get resume PDF path with validation and formatting.
+   * Remote URLs are returned as-is; local paths are prefixed with
+   * VITE_ROOT_PATH so GitHub Pages subpath deploys resolve correctly.
    */
   getResumePdfPath(): string {
     const path = env.RESUME_PDF_PATH || "/resume.pdf";
 
-    // If it's a full URL, return as is
     if (path.match(/^https?:\/\//)) return path;
 
-    // If it starts with /, return as is
-    if (path.startsWith("/")) return path;
+    const root = this.getRootPath().replace(/\/$/, "");
+    const cleanPath = path.replace(/^\//, "");
 
-    // Otherwise prepend /
-    return `/${path}`;
+    return root === "" ? `/${cleanPath}` : `${root}/${cleanPath}`;
   },
 } as const;
 

--- a/src/utils/resumeLoader.ts
+++ b/src/utils/resumeLoader.ts
@@ -1,4 +1,5 @@
 import { envHelpers } from "@/utils/env";
+import { buildPath } from "@/utils/pathUtils";
 
 // Dynamically import js-yaml to reduce initial bundle size
 let yamlModule: typeof import("js-yaml") | null = null;
@@ -355,7 +356,10 @@ function getResumeSource(): string {
     return convertGistToRawURL(resumeFile);
   }
 
-  return resumeFile.startsWith("/") ? resumeFile : `/${resumeFile}`;
+  // Local files live under the Vite `base` (VITE_ROOT_PATH). On GitHub Pages
+  // subpath deploys (e.g. /resume/) a bare "/resume.yaml" would 404 because
+  // the asset is actually served at "/resume/resume.yaml".
+  return buildPath(resumeFile);
 }
 
 // ===============================================


### PR DESCRIPTION
## Problem

After #89 merged, `https://mai0313.github.io/resume/resume` shows:

> Unable to load resume content. Please check your resume configuration or try refreshing the page.

## Root cause

`getResumeSource()` and `getResumePdfPath()` returned bare `/resume.yaml` / `/resume.pdf` without prefixing `VITE_ROOT_PATH`. GitHub Pages serves the whole site under `/resume/` (repo name), so the actual asset lives at `https://mai0313.github.io/resume/resume.yaml` — but the runtime fetch hit `https://mai0313.github.io/resume.yaml` and got a 404.

Verified with curl:
- `https://mai0313.github.io/resume/resume.yaml` → **200** ✓ (where the file actually is)
- `https://mai0313.github.io/resume.yaml` → **404** ✗ (where the code was looking)

The GitHub Actions workflow is fine — it sets `VITE_ROOT_PATH=/resume` correctly. The bug is purely in the client-side path resolution.

## Fix

- `src/utils/resumeLoader.ts::getResumeSource()` — route local paths through existing `buildPath()` helper so they get `VITE_ROOT_PATH` prefixed. Remote URLs (Gist / raw) still short-circuit unchanged.
- `src/utils/env.ts::getResumePdfPath()` — inline the same prefix logic (env.ts can't import pathUtils without creating a circular dep).

Net: `resume.yaml` now resolves to `/resume/resume.yaml` and `resume.pdf` to `/resume/resume.pdf` on GH Pages; in local dev (`VITE_ROOT_PATH=/`) both still resolve to `/resume.yaml` and `/resume.pdf` as before.

## Test plan
- [x] `yarn run check` (tsc + prettier + eslint) passes
- [x] `VITE_ROOT_PATH=/resume yarn build` succeeds; bundle contains `/resume` string literal
- [ ] Deploy preview on GitHub Pages resolves the resume correctly
- [ ] PDF download button points at `/resume/resume.pdf`