### PR TITLE
refactor: clean up dead code and config hygiene

### DIFF
--- a/.github/workflows/auto_labeler.yml
+++ b/.github/workflows/auto_labeler.yml
@@ -11,9 +11,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Disable SSL Verify
-        run: git config --global http.sslVerify false
-
       - name: Checkout
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -32,29 +32,11 @@ jobs:
             tag: ghcr.io/${{ github.repository }}
 
     steps:
-      - name: Disable SSL Verify
-        run: git config --global http.sslVerify false
-
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      # - name: Setup uv
-      #   uses: astral-sh/setup-uv@v7
-      #   with:
-      #     version: "latest"
-      #     github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      # - name: Update Version
-      #   id: version
-      #   shell: bash
-      #   run: |
-      #     VERSION=$(uvx dunamai from git --bump --no-metadata --style pep440)
-      #     uv version $VERSION --frozen
-      #     echo "VERSION=$VERSION" >> $GITHUB_ENV
-      #     echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Login to the Container registry
         uses: docker/login-action@v4
@@ -77,7 +59,6 @@ jobs:
           images: ${{ matrix.target.tag }}
           tags: |
             latest
-            ${{ steps.version.outputs.version }}
 
       - name: Extract Image Name
         id: extracted_name

--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -17,9 +17,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Disable SSL Verify
-        run: git config --global http.sslVerify false
-
       - name: Checkout
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -15,9 +15,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Disable SSL Verify
-        run: git config --global http.sslVerify false
-
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -39,9 +36,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Disable SSL Verify
-        run: git config --global http.sslVerify false
-
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -59,9 +53,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Disable SSL Verify
-        run: git config --global http.sslVerify false
-
       - name: Checkout
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,9 +16,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Disable SSL Verify
-        run: git config --global http.sslVerify false
-
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -27,6 +24,8 @@ jobs:
 
       - name: Setup node
         uses: actions/setup-node@v6
+        with:
+          node-version: 22
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -15,9 +15,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Disable SSL Verify
-        run: git config --global http.sslVerify false
-
       - name: Checkout
         uses: actions/checkout@v6
         with:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,26 +1,13 @@
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
 import { defineConfig, globalIgnores } from "eslint/config";
-import { fixupConfigRules, fixupPluginRules } from "@eslint/compat";
 import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
 import unusedImports from "eslint-plugin-unused-imports";
 import _import from "eslint-plugin-import";
 import typescriptEslint from "@typescript-eslint/eslint-plugin";
 import jsxA11Y from "eslint-plugin-jsx-a11y";
-import prettier from "eslint-plugin-prettier";
+import prettierRecommended from "eslint-plugin-prettier/recommended";
 import globals from "globals";
 import tsParser from "@typescript-eslint/parser";
-import js from "@eslint/js";
-import { FlatCompat } from "@eslint/eslintrc";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
-  allConfig: js.configs.all,
-});
 
 export default defineConfig([
   globalIgnores([
@@ -32,21 +19,16 @@ export default defineConfig([
     "**/build",
   ]),
   {
-    extends: fixupConfigRules(
-      compat.extends(
-        "plugin:react/recommended",
-        "plugin:prettier/recommended",
-        "plugin:react-hooks/recommended",
-        "plugin:jsx-a11y/recommended",
-      ),
-    ),
+    extends: [
+      react.configs.flat.recommended,
+      prettierRecommended,
+      reactHooks.configs["recommended-latest"],
+      jsxA11Y.flatConfigs.recommended,
+    ],
     plugins: {
-      "react": fixupPluginRules(react),
       "unused-imports": unusedImports,
-      "import": fixupPluginRules(_import),
+      "import": _import,
       "@typescript-eslint": typescriptEslint,
-      "jsx-a11y": fixupPluginRules(jsxA11Y),
-      "prettier": fixupPluginRules(prettier),
     },
     languageOptions: {
       globals: {

--- a/index.html
+++ b/index.html
@@ -3,13 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>%VITE_WEBSITE_TITLE%</title>
     <meta
-      key="viewport"
       content="viewport-fit=cover, width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"
       name="viewport"
     />
+    <title>%VITE_WEBSITE_TITLE%</title>
     <meta name="description" content="%VITE_WEBSITE_TITLE% - Resume" />
 
     <!-- Theme color (used by Discord embed sidebar, Chrome mobile, etc.) -->
@@ -18,7 +16,7 @@
     <!-- Open Graph / Facebook / LinkedIn / Discord -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="%VITE_WEBSITE_TITLE%" />
-    <meta key="title" property="og:title" content="%VITE_WEBSITE_TITLE%" />
+    <meta property="og:title" content="%VITE_WEBSITE_TITLE%" />
     <meta property="og:description" content="%VITE_WEBSITE_TITLE% - Resume" />
 
     <!-- Twitter / X -->
@@ -26,7 +24,6 @@
     <meta name="twitter:title" content="%VITE_WEBSITE_TITLE%" />
     <meta name="twitter:description" content="%VITE_WEBSITE_TITLE% - Resume" />
 
-    <link href="/favicon.ico" rel="icon" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ogl": "^1.0.11",
     "react": "18",
     "react-dom": "18",
-    "react-router-dom": "^7.12.0",
+    "react-router-dom": "^7.15.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.1.18"
   },

--- a/package.json
+++ b/package.json
@@ -32,9 +32,6 @@
     "tailwindcss": "^4.1.18"
   },
   "devDependencies": {
-    "@eslint/compat": "1.2.9",
-    "@eslint/eslintrc": "3.3.1",
-    "@eslint/js": "9.25.1",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "24.0.1",
     "@types/react": "19.1.7",

--- a/src/components/DecryptedText/DecryptedText.tsx
+++ b/src/components/DecryptedText/DecryptedText.tsx
@@ -3,9 +3,9 @@ import {
   useState,
   useRef,
   useCallback,
+  type ComponentPropsWithoutRef,
   type CSSProperties,
 } from "react";
-import { motion, type HTMLMotionProps } from "framer-motion";
 
 type RevealDirection = "start" | "end" | "center";
 
@@ -18,7 +18,7 @@ interface DecryptedTextOwnProps {
 }
 
 type DecryptedTextProps = DecryptedTextOwnProps &
-  Omit<HTMLMotionProps<"span">, keyof DecryptedTextOwnProps>;
+  Omit<ComponentPropsWithoutRef<"span">, keyof DecryptedTextOwnProps>;
 
 const AVAILABLE_CHARS =
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!@#$%^&*()_+".split("");
@@ -174,7 +174,7 @@ export default function DecryptedText({
   }, [hasAnimated, triggerDecrypt]);
 
   return (
-    <motion.span ref={containerRef} style={styles.wrapper} {...props}>
+    <span ref={containerRef} style={styles.wrapper} {...props}>
       <span style={styles.srOnly}>{displayText}</span>
 
       <span aria-hidden="true">
@@ -191,6 +191,6 @@ export default function DecryptedText({
           );
         })}
       </span>
-    </motion.span>
+    </span>
   );
 }

--- a/src/components/ResumeSections/BulletSection.tsx
+++ b/src/components/ResumeSections/BulletSection.tsx
@@ -23,12 +23,7 @@ export const BulletSection: React.FC<BulletSectionProps> = ({
   const items = entries?.map((entry) => entry.bullet) ?? [];
 
   return (
-    <SectionCard
-      data={entries}
-      itemVariants={itemVariants}
-      sectionKey={sectionName}
-      title={displayTitle}
-    >
+    <SectionCard itemVariants={itemVariants} title={displayTitle}>
       <BulletList items={items} />
     </SectionCard>
   );

--- a/src/components/ResumeSections/EducationSection.tsx
+++ b/src/components/ResumeSections/EducationSection.tsx
@@ -22,12 +22,7 @@ export const EducationSection: React.FC<EducationSectionProps> = ({
   const { displayTitle } = getSectionConfig(sectionName);
 
   return (
-    <SectionCard
-      data={entries}
-      itemVariants={itemVariants}
-      sectionKey={sectionName}
-      title={displayTitle}
-    >
+    <SectionCard itemVariants={itemVariants} title={displayTitle}>
       <div className="divide-y divide-border">
         {entries?.map((edu, index) => (
           <ItemCard

--- a/src/components/ResumeSections/ExperienceSection.tsx
+++ b/src/components/ResumeSections/ExperienceSection.tsx
@@ -26,12 +26,7 @@ export const ExperienceSection: React.FC<ExperienceSectionProps> = ({
   const { displayTitle } = getSectionConfig(sectionName);
 
   return (
-    <SectionCard
-      data={entries}
-      itemVariants={itemVariants}
-      sectionKey={sectionName}
-      title={displayTitle}
-    >
+    <SectionCard itemVariants={itemVariants} title={displayTitle}>
       <div className="divide-y divide-border">
         {entries?.map((entry, index) => (
           <ItemCard

--- a/src/components/ResumeSections/NormalSection.tsx
+++ b/src/components/ResumeSections/NormalSection.tsx
@@ -28,12 +28,7 @@ export const NormalSection: React.FC<NormalSectionProps> = ({
   const { displayTitle } = getSectionConfig(sectionName);
 
   return (
-    <SectionCard
-      data={entries}
-      itemVariants={itemVariants}
-      sectionKey={sectionName}
-      title={displayTitle}
-    >
+    <SectionCard itemVariants={itemVariants} title={displayTitle}>
       <div className="divide-y divide-border">
         {entries?.map((entry, index) => {
           const metaLine = formatList([

--- a/src/components/ResumeSections/OneLineSection.tsx
+++ b/src/components/ResumeSections/OneLineSection.tsx
@@ -30,12 +30,7 @@ export const OneLineSection: React.FC<OneLineSectionProps> = ({
   );
 
   return (
-    <SectionCard
-      data={entries}
-      itemVariants={itemVariants}
-      sectionKey={sectionName}
-      title={displayTitle}
-    >
+    <SectionCard itemVariants={itemVariants} title={displayTitle}>
       {hasKeywords ? (
         <div className="divide-y divide-border">
           {entries?.map((entry, index) => (

--- a/src/components/ResumeSections/PublicationSection.tsx
+++ b/src/components/ResumeSections/PublicationSection.tsx
@@ -26,12 +26,7 @@ export const PublicationSection: React.FC<PublicationSectionProps> = ({
   const { displayTitle } = getSectionConfig(sectionName);
 
   return (
-    <SectionCard
-      data={entries}
-      itemVariants={itemVariants}
-      sectionKey={sectionName}
-      title={displayTitle}
-    >
+    <SectionCard itemVariants={itemVariants} title={displayTitle}>
       <div className="divide-y divide-border">
         {entries?.map((pub, index) => {
           const url =

--- a/src/components/ResumeSections/SectionCard.tsx
+++ b/src/components/ResumeSections/SectionCard.tsx
@@ -4,9 +4,7 @@ import { motion, Variants } from "framer-motion";
 interface SectionCardProps {
   title: string;
   itemVariants: Variants;
-  sectionKey: string;
   children: ReactNode;
-  data?: unknown[];
 }
 
 /**
@@ -16,20 +14,10 @@ interface SectionCardProps {
 export const SectionCard: React.FC<SectionCardProps> = ({
   title,
   itemVariants,
-  sectionKey,
   children,
-  data,
 }) => {
-  if (data !== undefined && (!data || data.length === 0)) {
-    return null;
-  }
-
   return (
-    <motion.section
-      key={sectionKey}
-      className="scroll-mt-24"
-      variants={itemVariants}
-    >
+    <motion.section className="scroll-mt-24" variants={itemVariants}>
       <div className="mb-8 flex items-baseline gap-4">
         <h2 className="label-mono text-fg">{title}</h2>
         <span className="h-px flex-1 bg-border" />

--- a/src/components/ResumeSections/TextSection.tsx
+++ b/src/components/ResumeSections/TextSection.tsx
@@ -17,12 +17,7 @@ export const TextSection: React.FC<TextSectionProps> = ({
   const { displayTitle } = getSectionConfig(sectionName);
 
   return (
-    <SectionCard
-      data={entries}
-      itemVariants={itemVariants}
-      sectionKey={sectionName}
-      title={displayTitle}
-    >
+    <SectionCard itemVariants={itemVariants} title={displayTitle}>
       <div className="max-w-3xl space-y-4">
         {entries?.map((text, index) => (
           <p

--- a/src/components/shared/BulletList.tsx
+++ b/src/components/shared/BulletList.tsx
@@ -4,22 +4,16 @@ import { cn } from "@/lib/utils";
 
 interface BulletListProps {
   items: string[];
-  title?: string;
   className?: string;
 }
 
-export const BulletList: FC<BulletListProps> = ({
-  items,
-  title,
-  className = "",
-}) => {
+export const BulletList: FC<BulletListProps> = ({ items, className = "" }) => {
   if (!items || items.length === 0) {
     return null;
   }
 
   return (
     <div className={className}>
-      {title && <h4 className="label-mono mb-3 text-fg-subtle">{title}</h4>}
       <ul className="space-y-2.5">
         {items.map((item, index) => (
           <li

--- a/src/utils/resume/listFields.ts
+++ b/src/utils/resume/listFields.ts
@@ -6,7 +6,7 @@ const LIST_FIELDS = ["keywords", "roles", "courses"] as const;
  * Normalize a field that may arrive as a comma-separated string or as an array.
  * Missing or unsupported values return undefined so callers can delete them.
  */
-export function normalizeListField(value: unknown): string[] | undefined {
+function normalizeListField(value: unknown): string[] | undefined {
   if (value == null) {
     return undefined;
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,7 +39,6 @@ const createSpa404Plugin = () => {
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), tsconfigPaths(), tailwindcss(), createSpa404Plugin()],
-  assetsInclude: ["**/*.yaml", "**/*.yml"],
   // 支援自定義 ROOT PATH，從環境變數 VITE_ROOT_PATH 讀取
   base: process.env.VITE_ROOT_PATH || "/",
   server: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3103,17 +3103,17 @@ react-refresh@^0.17.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.17.0.tgz#b7e579c3657f23d04eccbe4ad2e58a8ed51e7e53"
   integrity sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==
 
-react-router-dom@^7.12.0:
-  version "7.14.1"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-7.14.1.tgz#1ead5007f8948b6eae6df84e95cc109911ad5d7c"
-  integrity sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA==
+react-router-dom@^7.15.0:
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-7.16.0.tgz#284a7cd021052aa7d0a9240dca4a02eec24eceb5"
+  integrity sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==
   dependencies:
-    react-router "7.14.1"
+    react-router "7.16.0"
 
-react-router@7.14.1:
-  version "7.14.1"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.14.1.tgz#adf60e587ad7fb25bd8f33c443fb0e86cd4f051e"
-  integrity sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg==
+react-router@7.16.0:
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.16.0.tgz#fb41536aef2ccc2c7be12ea6be819a1e56eb6343"
+  integrity sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==
   dependencies:
     cookie "^1.0.1"
     set-cookie-parser "^2.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -324,11 +324,6 @@
   resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.12.2.tgz#bccdf615bcf7b6e8db830ec0b8d21c9a25de597b"
   integrity sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==
 
-"@eslint/compat@1.2.9":
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/@eslint/compat/-/compat-1.2.9.tgz#1a234508c30660fdf10dd7bed2d37cc86c8d8f53"
-  integrity sha512-gCdSY54n7k+driCadyMNv8JSPzYLeDVM/ikZRtvtROBpRdFSkS8W9A82MqsaY7lZuwL0wiapgD0NT1xT0hyJsA==
-
 "@eslint/config-array@^0.21.2":
   version "0.21.2"
   resolved "https://registry.yarnpkg.com/@eslint/config-array/-/config-array-0.21.2.tgz#f29e22057ad5316cf23836cee9a34c81fffcb7e6"
@@ -352,21 +347,6 @@
   dependencies:
     "@types/json-schema" "^7.0.15"
 
-"@eslint/eslintrc@3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-3.3.1.tgz#e55f7f1dd400600dd066dbba349c4c0bac916964"
-  integrity sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==
-  dependencies:
-    ajv "^6.12.4"
-    debug "^4.3.2"
-    espree "^10.0.1"
-    globals "^14.0.0"
-    ignore "^5.2.0"
-    import-fresh "^3.2.1"
-    js-yaml "^4.1.0"
-    minimatch "^3.1.2"
-    strip-json-comments "^3.1.1"
-
 "@eslint/eslintrc@^3.3.5":
   version "3.3.5"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-3.3.5.tgz#c131793cfc1a7b96f24a83e0a8bbd4b881558c60"
@@ -381,11 +361,6 @@
     js-yaml "^4.1.1"
     minimatch "^3.1.5"
     strip-json-comments "^3.1.1"
-
-"@eslint/js@9.25.1":
-  version "9.25.1"
-  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-9.25.1.tgz#25f5c930c2b68b5ebe7ac857f754cbd61ef6d117"
-  integrity sha512-dEIwmjntEx8u3Uvv+kr3PDeeArL8Hw07H9kyYxCjnM9pBjfEhk6uLXSchxxzgiwtRhhzVzqmUSDFBOi1TuZ7qg==
 
 "@eslint/js@9.39.4":
   version "9.39.4"
@@ -1194,7 +1169,7 @@ acorn@^8.15.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
 
-ajv@^6.12.4, ajv@^6.14.0:
+ajv@^6.14.0:
   version "6.14.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.14.0.tgz#fd067713e228210636ebb08c60bd3765d6dbe73a"
   integrity sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==


### PR DESCRIPTION
## Summary

Behavior-preserving cleanup pass. No visual or functional change, plus one deliberate dependency security bump (called out below).

- Remove dead code in resume components: unexport internal-only `normalizeListField`, drop the never-used `BulletList.title` prop, and replace `DecryptedText`'s `motion.span` wrapper with a plain `span` (no motion features were used)
- Simplify `SectionCard`: drop the redundant `data` empty-guard (the renderer already short-circuits empty sections) and the `sectionKey` prop (React keys are owned by the caller)
- Migrate ESLint to pure flat config: drop `@eslint/compat` / `@eslint/eslintrc` legacy bridges in favor of each plugin's native flat config; resolved rule set verified identical via `--print-config` diff (248 rules)
- CI hygiene: remove `git config --global http.sslVerify false` steps from all workflows, delete commented-out dead steps in `build_image.yml`, pin `setup-node` to Node 22 in deploy
- Tidy config: remove unused `assetsInclude` from `vite.config.ts`, dedupe favicon/viewport tags in `index.html`
- Bump `react-router-dom` to `^7.15.0` (resolves to 7.16.0). Deliberate, non-cleanup change: react-router published two HIGH security advisories (GHSA fixed in >=7.14.2 / >=7.15.0) that started failing the Trivy CI gate; the bump patches them. `yarn audit --level high` is clean and the full check/build/preview verification below was re-run on the bumped lockfile.

## Verification

- `yarn run check` (tsc + prettier + eslint) clean
- `yarn build` green; chunk layout unchanged
- ESLint resolved config diffed against baseline: identical
- `yarn preview` smoke test: `/`, `/resume`, `/resume.yaml`, `/resume.pdf` and built assets all 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)