### PR TITLE
feat: refine visual design with Geist typography and theme-aware accents

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,13 @@
     <meta name="description" content="%VITE_WEBSITE_TITLE% - Resume" />
 
     <!-- Theme color (used by Discord embed sidebar, Chrome mobile, etc.) -->
-    <meta name="theme-color" content="#020b10" />
+    <!-- Values mirror the --background tokens in src/styles/globals.css -->
+    <meta
+      name="theme-color"
+      media="(prefers-color-scheme: light)"
+      content="#f9fafb"
+    />
+    <meta name="theme-color" content="#040b10" />
 
     <!-- Open Graph / Facebook / LinkedIn / Discord -->
     <meta property="og:type" content="website" />

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "lint:nofix": "eslint"
   },
   "dependencies": {
+    "@fontsource-variable/geist": "^5.2.9",
+    "@fontsource-variable/geist-mono": "^5.2.8",
     "@heroui/react": "^3.1.0",
     "@heroui/styles": "^3.1.0",
     "@tailwindcss/vite": "^4.1.18",

--- a/src/components/ResumeHeader.tsx
+++ b/src/components/ResumeHeader.tsx
@@ -54,12 +54,14 @@ export function ResumeHeader({ cv, languages }: ResumeHeaderProps) {
           <div className="mb-8">
             <Chip size="sm" variant="soft">
               <span className="size-1.5 rounded-full bg-success" />
-              <Chip.Label>PROFILE · {formatUpdatedAt()}</Chip.Label>
+              <Chip.Label className="font-mono text-[0.7rem] tracking-wide">
+                PROFILE · {formatUpdatedAt()}
+              </Chip.Label>
             </Chip>
           </div>
 
           <Typography.Heading
-            className="mb-4 text-5xl font-bold tracking-tight text-foreground md:text-7xl"
+            className="mb-4 text-5xl font-bold leading-[1.05] tracking-[-0.02em] text-foreground md:text-7xl"
             level={1}
           >
             {cv.name}
@@ -77,7 +79,7 @@ export function ResumeHeader({ cv, languages }: ResumeHeaderProps) {
           <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-muted">
             {cv.location && (
               <Typography
-                className="text-sm leading-5 text-muted"
+                className="font-mono text-sm leading-5 text-muted"
                 type="body-sm"
               >
                 {cv.location}
@@ -85,14 +87,14 @@ export function ResumeHeader({ cv, languages }: ResumeHeaderProps) {
             )}
             {cv.location && cv.email && (
               <Typography
-                className="text-sm leading-5 text-muted/50"
+                className="font-mono text-sm leading-5 text-muted/50"
                 type="body-sm"
               >
                 ·
               </Typography>
             )}
             {cv.email && (
-              <Link className="text-sm" href={`mailto:${cv.email}`}>
+              <Link className="font-mono text-sm" href={`mailto:${cv.email}`}>
                 {cv.email}
               </Link>
             )}
@@ -116,7 +118,7 @@ export function ResumeHeader({ cv, languages }: ResumeHeaderProps) {
 
         {cv.photo && (
           <div className="order-1 flex justify-start md:order-2 md:justify-end">
-            <Avatar className="size-24 md:size-32">
+            <Avatar className="size-24 ring-1 ring-border md:size-32">
               <Avatar.Image alt={cv.name} src={cv.photo} />
               <Avatar.Fallback>{initials(cv.name)}</Avatar.Fallback>
             </Avatar>
@@ -127,7 +129,7 @@ export function ResumeHeader({ cv, languages }: ResumeHeaderProps) {
       {languages && languages.entries.length > 0 && (
         <div className="mt-10 grid grid-cols-[auto_1fr] items-center gap-x-8 border-t border-border pt-6">
           <Typography
-            className="text-xs font-semibold uppercase leading-4 tracking-wider text-muted"
+            className="font-mono text-xs font-medium uppercase leading-4 tracking-[0.15em] text-muted"
             type="body-xs"
           >
             Languages

--- a/src/components/ResumeSections/EducationSection.tsx
+++ b/src/components/ResumeSections/EducationSection.tsx
@@ -44,7 +44,7 @@ export const EducationSection: FC<EducationSectionProps> = ({
             {edu.courses && edu.courses.length > 0 && (
               <div className="border-l border-border pl-4">
                 <Typography
-                  className="mb-2 text-xs font-medium uppercase leading-4 tracking-wider text-muted"
+                  className="mb-2 font-mono text-xs font-medium uppercase leading-4 tracking-[0.15em] text-muted"
                   type="body-xs"
                 >
                   Coursework

--- a/src/components/ResumeSections/NormalSection.tsx
+++ b/src/components/ResumeSections/NormalSection.tsx
@@ -42,7 +42,7 @@ export const NormalSection: FC<NormalSectionProps> = ({
               <div className="mb-4 flex flex-col gap-1 md:flex-row md:items-baseline md:justify-between md:gap-6">
                 <div className="flex-1">
                   <Typography.Heading
-                    className="text-lg font-semibold tracking-normal text-foreground"
+                    className="text-lg font-semibold leading-snug tracking-normal text-foreground"
                     level={3}
                   >
                     <ExternalLink className="text-foreground" url={entry.url}>
@@ -51,7 +51,7 @@ export const NormalSection: FC<NormalSectionProps> = ({
                   </Typography.Heading>
                   {metaLine && (
                     <Typography
-                      className="mt-1.5 text-xs leading-4 text-muted"
+                      className="mt-1.5 font-mono text-xs leading-4 text-muted"
                       type="body-xs"
                     >
                       {metaLine}
@@ -83,7 +83,12 @@ export const NormalSection: FC<NormalSectionProps> = ({
               {entry.keywords && entry.keywords.length > 0 && (
                 <div className="flex flex-wrap gap-1.5">
                   {entry.keywords.map((keyword) => (
-                    <Chip key={keyword} size="sm" variant="soft">
+                    <Chip
+                      key={keyword}
+                      className="font-mono tracking-tight"
+                      size="sm"
+                      variant="soft"
+                    >
                       {keyword}
                     </Chip>
                   ))}

--- a/src/components/ResumeSections/OneLineSection.tsx
+++ b/src/components/ResumeSections/OneLineSection.tsx
@@ -39,14 +39,14 @@ export const OneLineSection: FC<OneLineSectionProps> = ({
             >
               <div className="mb-3 flex items-baseline justify-between gap-4">
                 <Typography.Heading
-                  className="text-base font-semibold tracking-normal text-foreground"
+                  className="text-base font-semibold leading-snug tracking-normal text-foreground"
                   level={3}
                 >
                   {entry.label}
                 </Typography.Heading>
                 {entry.details && (
                   <Typography
-                    className="shrink-0 text-xs leading-4 text-muted"
+                    className="shrink-0 font-mono text-xs leading-4 text-muted"
                     type="body-xs"
                   >
                     {entry.details}
@@ -56,7 +56,12 @@ export const OneLineSection: FC<OneLineSectionProps> = ({
               {entry.keywords && entry.keywords.length > 0 && (
                 <div className="flex max-w-3xl flex-wrap gap-1.5">
                   {entry.keywords.map((keyword) => (
-                    <Chip key={keyword} size="sm" variant="soft">
+                    <Chip
+                      key={keyword}
+                      className="font-mono tracking-tight"
+                      size="sm"
+                      variant="soft"
+                    >
                       {keyword}
                     </Chip>
                   ))}
@@ -80,7 +85,7 @@ export const OneLineSection: FC<OneLineSectionProps> = ({
               </Typography>
               {entry.details && (
                 <Typography
-                  className="text-xs leading-4 text-muted"
+                  className="font-mono text-xs leading-4 text-muted"
                   type="body-xs"
                 >
                   {entry.details}

--- a/src/components/ResumeSections/PublicationSection.tsx
+++ b/src/components/ResumeSections/PublicationSection.tsx
@@ -35,7 +35,7 @@ export const PublicationSection: FC<PublicationSectionProps> = ({
             <ItemCard key={`${sectionName}-${pub.title || "unknown"}-${index}`}>
               <div className="grid grid-cols-[auto_1fr_auto] items-baseline gap-4 md:gap-6">
                 <Typography
-                  className="font-mono text-xs leading-4 text-muted"
+                  className="font-mono text-xs leading-4 text-muted tabular-nums"
                   type="body-xs"
                 >
                   {String(index + 1).padStart(2, "0")}
@@ -55,7 +55,7 @@ export const PublicationSection: FC<PublicationSectionProps> = ({
                   </Typography.Heading>
                   {meta && (
                     <Typography
-                      className="mt-2 text-xs leading-4 text-muted"
+                      className="mt-2 font-mono text-xs leading-4 text-muted"
                       type="body-xs"
                     >
                       {meta}

--- a/src/components/ResumeSections/SectionCard.tsx
+++ b/src/components/ResumeSections/SectionCard.tsx
@@ -23,7 +23,7 @@ export const SectionCard: FC<SectionCardProps> = ({
     <m.section className="scroll-mt-24" variants={itemVariants}>
       <div className="mb-8 flex items-center gap-4">
         <Typography.Heading
-          className="text-xs font-semibold uppercase tracking-wider text-muted"
+          className="font-mono text-xs font-medium uppercase leading-4 tracking-[0.15em] text-muted"
           level={2}
         >
           {title}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -45,7 +45,7 @@ export const Navbar = () => {
               <Link
                 key={tab.href}
                 className={cn(
-                  "relative rounded-full px-3 py-1.5 text-sm font-medium transition-colors",
+                  "relative rounded-full px-3 py-1.5 text-sm font-medium tracking-tight transition-colors",
                   isActive
                     ? "text-foreground"
                     : "text-muted hover:text-foreground",

--- a/src/components/shared/BulletList.tsx
+++ b/src/components/shared/BulletList.tsx
@@ -16,7 +16,7 @@ export const BulletList: FC<BulletListProps> = ({ items, className = "" }) => {
 
   return (
     <ul
-      className={cn("list-disc space-y-2 pl-5 marker:text-muted/60", className)}
+      className={cn("list-disc space-y-2 pl-5 marker:text-muted/40", className)}
     >
       {items.map((item, index) => (
         // text-sm on the <li> keeps the ::marker sized to the body text.

--- a/src/components/shared/DateRange.tsx
+++ b/src/components/shared/DateRange.tsx
@@ -21,13 +21,16 @@ export const DateRange: FC<DateRangeProps> = ({
 
   let text = "";
 
-  if (startDate && endDate) text = `${startDate} — ${endDate}`;
+  if (startDate && endDate) text = `${startDate} - ${endDate}`;
   else if (startDate) text = startDate;
   else if (endDate) text = endDate;
 
   return (
     <Typography
-      className={cn("text-xs leading-4 text-muted", className)}
+      className={cn(
+        "font-mono text-xs leading-4 tracking-tight text-muted tabular-nums",
+        className,
+      )}
       type="body-xs"
     >
       {text}

--- a/src/components/shared/EntryHeader.tsx
+++ b/src/components/shared/EntryHeader.tsx
@@ -39,7 +39,7 @@ export const EntryHeader: FC<EntryHeaderProps> = ({
   >
     <div className="flex-1">
       <Typography.Heading
-        className="text-lg font-semibold tracking-normal text-foreground"
+        className="text-lg font-semibold leading-snug tracking-normal text-foreground"
         level={3}
       >
         <ExternalLink className="text-foreground" showIcon={false} url={url}>
@@ -59,7 +59,7 @@ export const EntryHeader: FC<EntryHeaderProps> = ({
       <DateRange endDate={endDate} startDate={startDate} />
       {rightMeta && (
         <Typography
-          className="mt-1 text-xs leading-4 text-muted"
+          className="mt-1 font-mono text-xs leading-4 text-muted"
           type="body-xs"
         >
           {rightMeta}

--- a/src/components/shared/ItemCard.tsx
+++ b/src/components/shared/ItemCard.tsx
@@ -14,7 +14,7 @@ interface ItemCardProps {
 export const ItemCard: FC<ItemCardProps> = ({ children, className = "" }) => (
   <div
     className={cn(
-      "group -mx-4 rounded-lg px-4 py-6 transition-colors duration-200 hover:bg-default/40",
+      "group -mx-4 rounded-lg px-4 py-6 transition-colors duration-200 hover:bg-default/30",
       className,
     )}
   >

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -13,6 +13,9 @@ const navItems = (() => {
 
 export const siteConfig = {
   navItems,
+  // Shown as the mono sub-line under the hero heading. Kept static so the
+  // home route bundle never needs to load the resume YAML.
+  tagline: "Software Engineer · Hsinchu, Taiwan",
   links: {
     github: "https://github.com/Mai0313",
   },

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,8 @@ import App from "./App.tsx";
 import ErrorBoundary from "./components/ErrorBoundary.tsx";
 
 import { getBasename } from "@/utils/pathUtils";
+import "@fontsource-variable/geist";
+import "@fontsource-variable/geist-mono";
 import "@/styles/globals.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,7 @@ import type { ComponentPropsWithRef } from "react";
 
 import { lazy, Suspense } from "react";
 import { Link as RouterLink } from "react-router-dom";
-import { Link, Typography } from "@heroui/react";
+import { Link, Typography, useTheme } from "@heroui/react";
 
 import DecryptedText from "@/components/DecryptedText/DecryptedText";
 import {
@@ -11,15 +11,21 @@ import {
   GitHubIcon,
 } from "@/components/shared";
 import DefaultLayout from "@/layouts/default";
+import { cn } from "@/lib/utils";
 import { siteConfig } from "@/config/site";
 import { env, envHelpers } from "@/utils/env";
 
 const Threads = lazy(() => import("@/components/Threads/Threads"));
 
-const THREADS_COLOR: [number, number, number] = [1, 1, 1];
+// Stable per-theme tuples: Threads rebuilds its WebGL context whenever the
+// color reference changes, so never pass an inline array literal.
+const THREADS_DARK: [number, number, number] = [1, 1, 1];
+const THREADS_LIGHT: [number, number, number] = [0.1, 0.15, 0.25];
 
 export default function IndexPage() {
   const resumeAvailable = envHelpers.isResumeFileAvailable();
+  const { resolvedTheme } = useTheme("dark");
+  const isDark = resolvedTheme !== "light";
 
   return (
     <DefaultLayout>
@@ -27,10 +33,17 @@ export default function IndexPage() {
       <section className="relative flex min-h-screen items-center overflow-hidden">
         <div
           aria-hidden="true"
-          className="pointer-events-none absolute inset-0 opacity-[0.28]"
+          className={cn(
+            "pointer-events-none absolute inset-0",
+            isDark ? "opacity-[0.28]" : "opacity-[0.18]",
+          )}
         >
           <Suspense fallback={null}>
-            <Threads amplitude={1.4} color={THREADS_COLOR} distance={0.25} />
+            <Threads
+              amplitude={1.4}
+              color={isDark ? THREADS_DARK : THREADS_LIGHT}
+              distance={0.25}
+            />
           </Suspense>
         </div>
         <div
@@ -40,7 +53,7 @@ export default function IndexPage() {
 
         <div className="relative z-10 mx-auto w-full max-w-6xl px-6 pb-24 pt-32 sm:pt-40">
           <Typography.Heading
-            className="mb-12 font-bold leading-[1.02] tracking-tight"
+            className="mb-6 font-bold leading-[1.02] tracking-[-0.02em]"
             level={1}
             style={{ fontSize: "clamp(3.25rem, 10vw, 7rem)" }}
           >
@@ -52,6 +65,13 @@ export default function IndexPage() {
               text={env.WEBSITE_TITLE}
             />
           </Typography.Heading>
+
+          <Typography
+            className="mb-12 font-mono text-sm leading-5 text-muted"
+            type="body-sm"
+          >
+            {siteConfig.tagline}
+          </Typography>
 
           <div className="flex flex-wrap items-center gap-3">
             {resumeAvailable && (
@@ -71,7 +91,7 @@ export default function IndexPage() {
                 }}
               >
                 View Resume
-                <ArrowRightIcon />
+                <ArrowRightIcon size={16} />
               </Link>
             )}
             <Link

--- a/src/pages/resume.tsx
+++ b/src/pages/resume.tsx
@@ -44,7 +44,17 @@ function ResumeLoadingSkeleton() {
       <Skeleton className="h-6 w-44 rounded-full" />
       <Skeleton className="mt-8 h-14 w-2/3 rounded-lg" />
       <Skeleton className="mt-4 h-6 w-1/2 rounded-lg" />
-      <div className="mt-12 space-y-3">
+      <Skeleton className="mt-6 h-4 w-64 rounded-lg" />
+      <div className="mt-8 flex gap-5">
+        <Skeleton className="h-4 w-20 rounded-lg" />
+        <Skeleton className="h-4 w-20 rounded-lg" />
+        <Skeleton className="h-4 w-28 rounded-lg" />
+      </div>
+      <div className="mt-16 flex items-center gap-4">
+        <Skeleton className="h-3 w-32 rounded-lg" />
+        <Skeleton className="h-px flex-1" />
+      </div>
+      <div className="mt-8 space-y-3">
         <Skeleton className="h-4 w-full rounded-lg" />
         <Skeleton className="h-4 w-5/6 rounded-lg" />
         <Skeleton className="h-4 w-4/6 rounded-lg" />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,2 +1,32 @@
 @import "tailwindcss";
 @import "@heroui/styles";
+
+@theme {
+  /* Geist font stack; families are registered by @fontsource-variable imports in main.tsx */
+  --font-sans:
+    "Geist Variable", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
+    "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-mono:
+    "Geist Mono Variable", ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
+@layer base {
+  /* Cool-tinted light theme; surface stays white so the navbar pill lifts off the page. */
+  :root,
+  .light,
+  .default,
+  [data-theme="light"],
+  [data-theme="default"] {
+    --background: oklch(0.985 0.002 240);
+  }
+
+  /* OLED blue-black dark theme tuned to the Threads hero; matches the meta theme-color. */
+  .dark,
+  [data-theme="dark"] {
+    --background: oklch(0.143 0.018 235);
+    --surface: oklch(0.21 0.012 235);
+    --border: oklch(0.26 0.01 235);
+    --separator: oklch(0.23 0.01 235);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -413,6 +413,16 @@
     "@eslint/core" "^0.17.0"
     levn "^0.4.1"
 
+"@fontsource-variable/geist-mono@^5.2.8":
+  version "5.2.8"
+  resolved "https://registry.yarnpkg.com/@fontsource-variable/geist-mono/-/geist-mono-5.2.8.tgz#b71fbb9d8332dde974adeba3dbe5180c4ce9e9aa"
+  integrity sha512-KI5bj+hkkRiHttYHmccotUZ80ZuZyai+RwI1d7UId0clkx/jXxlo8qYK8j54WzmpBjtMoEMPyllV7faDcj+6RA==
+
+"@fontsource-variable/geist@^5.2.9":
+  version "5.2.9"
+  resolved "https://registry.yarnpkg.com/@fontsource-variable/geist/-/geist-5.2.9.tgz#261356515cb97e51bee31991259776b7435f0bd8"
+  integrity sha512-TP+QSBG3wxKGPE33CbMy/L0Nu3qvJ6Fy81Yc4LnQ95xH+i+cfEp8fyU8/kfV14YwszxIFPhnoMTbjL71waVpyQ==
+
 "@formatjs/ecma402-abstract@2.3.6":
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz#d6ca9d3579054fe1e1a0a0b5e872e0d64922e4e1"


### PR DESCRIPTION
## Summary

Site-wide visual refinement in a "refined dark tech" direction (preserve + polish). Signature elements (dark OLED base, WebGL Threads hero, DecryptedText, floating pill navbar) are kept; typography and theming get an engineering-precision upgrade.

### Typography
- Self-hosted **Geist** (sans) and **Geist Mono** via Fontsource variable fonts, wired through Tailwind v4 `@theme` so they apply site-wide.
- Mono treatment scoped to metadata only: dates (with `tabular-nums`), section labels, contact row, journal/entity lines, level indicators, and technical keyword chips. All prose stays sans.
- Explicit `leading-*` paired with every Typography size override to avoid HeroUI's BEM line-height fallback.

### Theming
- Dark `--background` retuned to a cool OLED blue-black matching the Threads hero; `--surface`, `--border`, `--separator` adjusted to keep hairline contrast.
- Light theme gets a cool-tinted near-white background with equal polish.
- `theme-color` meta now mirrors the actual painted backgrounds, with a light-mode media variant.

### Fixes
- Threads hero was hardcoded white and nearly invisible in light mode; it now switches colors and opacity per theme using stable tuples (avoids WebGL context churn).
- Date ranges no longer use an em-dash separator.
- Loading skeleton updated to mirror the new resume header layout.

### Verification
- `yarn run check` and `yarn build` pass; route chunks remain split (resume deps stay out of the home bundle), latin font subsets add ~59 KB.
- Headless Chrome CDP screenshots verified in both themes at 1440px and 390px for both pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)