### PR TITLE
feat: redesign resume site

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,11 @@
     "lint:nofix": "eslint"
   },
   "dependencies": {
+    "@fontsource-variable/geist": "^5.2.9",
+    "@fontsource-variable/geist-mono": "^5.2.8",
     "@heroui/react": "^3.1.0",
     "@heroui/styles": "^3.1.0",
+    "@phosphor-icons/react": "^2.1.10",
     "@tailwindcss/vite": "^4.1.18",
     "framer-motion": "^12.15.0",
     "js-yaml": "^4.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ const ResumePage = lazy(() => import("@/pages/resume"));
 
 function RouteFallback() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background">
+    <div className="flex min-h-[100dvh] items-center justify-center bg-background">
       <Spinner size="lg" />
     </div>
   );

--- a/src/components/ResumeContent.tsx
+++ b/src/components/ResumeContent.tsx
@@ -16,29 +16,32 @@ export const ResumeContent = ({ data }: ResumeContentProps) => {
   const { container: containerVariants, item: itemVariants } = fadeInStagger;
   const { cv } = data;
   const languages = findLanguagesSection(cv.sections);
+  const visibleSections = data.sectionOrder.filter(
+    (sectionName) => !(languages && sectionName === languages.key),
+  );
 
   return (
     <m.div
       animate="visible"
-      className="mx-auto max-w-4xl px-6 pb-24 pt-32 sm:pt-40"
+      className="mx-auto grid w-full max-w-7xl grid-cols-1 gap-10 px-4 pb-24 pt-28 sm:px-6 sm:pt-36 lg:grid-cols-[minmax(270px,340px)_minmax(0,1fr)] lg:gap-12 lg:pt-36"
       initial="hidden"
       variants={containerVariants}
     >
-      <m.div variants={itemVariants}>
+      <m.div
+        className="lg:sticky lg:top-28 lg:self-start"
+        variants={itemVariants}
+      >
         <ResumeHeader cv={cv} languages={languages} />
       </m.div>
 
-      <div className="space-y-20 md:space-y-24">
-        {data.sectionOrder.map((sectionName) => {
-          if (languages && sectionName === languages.key) {
-            return null;
-          }
-
+      <div className="space-y-12 lg:space-y-14">
+        {visibleSections.map((sectionName, index) => {
           return (
             <ResumeSectionRenderer
               key={sectionName}
               entries={cv.sections[sectionName]}
               itemVariants={itemVariants}
+              sectionIndex={index + 1}
               sectionName={sectionName}
             />
           );

--- a/src/components/ResumeHeader.tsx
+++ b/src/components/ResumeHeader.tsx
@@ -3,7 +3,15 @@ import type { LanguagesSection } from "@/components/ResumeSections/languages";
 
 import { Avatar, Chip, Link, Typography } from "@heroui/react";
 
-import { ExternalLink } from "@/components/shared";
+import {
+  ArrowUpRightIcon,
+  DownloadIcon,
+  FilePdfIcon,
+  GitHubIcon,
+  LinkedInIcon,
+  MailIcon,
+  MapPinIcon,
+} from "@/components/shared";
 import { env } from "@/utils/env";
 import { resolveAssetPath } from "@/utils/pathUtils";
 import { buildSocialUrl } from "@/utils/resume";
@@ -44,107 +52,139 @@ function initials(name: string): string {
     .toUpperCase();
 }
 
+function SocialIcon({ network }: { network: string }) {
+  const normalized = network.toLowerCase();
+
+  if (normalized.includes("github")) {
+    return <GitHubIcon size={16} />;
+  }
+
+  if (normalized.includes("linkedin")) {
+    return <LinkedInIcon size={16} />;
+  }
+
+  return <ArrowUpRightIcon size={16} />;
+}
+
 export function ResumeHeader({ cv, languages }: ResumeHeaderProps) {
   const pdfPath = resolveAssetPath(env.RESUME_PDF_PATH);
 
   return (
-    <header className="mb-16 border-b border-border pb-14 md:mb-20 md:pb-20">
-      <div className="grid grid-cols-1 gap-8 md:grid-cols-[1fr_auto] md:items-start md:gap-10">
-        <div className="order-2 md:order-1">
-          <div className="mb-8">
-            <Chip size="sm" variant="soft">
-              <span className="size-1.5 rounded-full bg-success" />
-              <Chip.Label>PROFILE · {formatUpdatedAt()}</Chip.Label>
-            </Chip>
-          </div>
+    <header className="rounded-[2rem] border border-border/70 bg-default/45 p-2 shadow-[var(--surface-shadow)]">
+      <div className="rounded-[1.5rem] border border-border/65 bg-surface/86 p-5 sm:p-6">
+        <div className="flex items-start justify-between gap-5">
+          <Chip className="font-mono" size="sm" variant="soft">
+            <span className="size-1.5 rounded-full bg-accent" />
+            <Chip.Label>{formatUpdatedAt()}</Chip.Label>
+          </Chip>
 
-          <Typography.Heading
-            className="mb-4 text-5xl font-bold tracking-tight text-foreground md:text-7xl"
-            level={1}
+          <Avatar className="size-16 rounded-2xl border border-border/70 bg-default text-foreground">
+            {cv.photo && <Avatar.Image alt={cv.name} src={cv.photo} />}
+            <Avatar.Fallback>{initials(cv.name)}</Avatar.Fallback>
+          </Avatar>
+        </div>
+
+        <Typography.Heading
+          className="mt-9 text-4xl font-semibold leading-none tracking-normal text-foreground sm:text-5xl lg:text-4xl xl:text-5xl"
+          level={1}
+        >
+          {cv.name}
+        </Typography.Heading>
+
+        {cv.headline && (
+          <Typography
+            className="mt-4 text-base font-medium leading-7 text-muted"
+            type="body"
           >
-            {cv.name}
-          </Typography.Heading>
+            {cv.headline}
+          </Typography>
+        )}
 
-          {cv.headline && (
-            <Typography
-              className="mb-10 text-xl leading-7 text-muted md:text-2xl md:leading-8"
-              type="body"
-            >
-              {cv.headline}
-            </Typography>
-          )}
-
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-muted">
-            {cv.location && (
+        <div className="mt-7 space-y-3 border-y border-border/70 py-5">
+          {cv.location && (
+            <div className="grid grid-cols-[1rem_1fr] items-center gap-3 text-sm text-muted">
+              <MapPinIcon size={16} />
               <Typography
-                className="text-sm leading-5 text-muted"
+                className="text-sm leading-6 text-muted"
                 type="body-sm"
               >
                 {cv.location}
               </Typography>
-            )}
-            {cv.location && cv.email && (
-              <Typography
-                className="text-sm leading-5 text-muted/50"
-                type="body-sm"
-              >
-                ·
-              </Typography>
-            )}
-            {cv.email && (
-              <Link className="text-sm" href={`mailto:${cv.email}`}>
-                {cv.email}
-              </Link>
-            )}
-          </div>
-
-          <div className="mt-8 flex flex-wrap items-center gap-x-5 gap-y-3">
-            {cv.social_networks?.map(({ network, username }) => (
-              <ExternalLink
-                key={network}
-                className="text-sm"
-                url={buildSocialUrl(network, username)}
-              >
-                {network}
-              </ExternalLink>
-            ))}
-            <ExternalLink className="text-sm" url={pdfPath}>
-              Download PDF
-            </ExternalLink>
-          </div>
+            </div>
+          )}
+          {cv.email && (
+            <Link
+              className="grid grid-cols-[1rem_1fr] items-center gap-3 text-sm text-muted no-underline transition-colors duration-500 ease-[cubic-bezier(0.32,0.72,0,1)] hover:text-foreground"
+              href={`mailto:${cv.email}`}
+            >
+              <MailIcon size={16} />
+              <span className="truncate">{cv.email}</span>
+            </Link>
+          )}
         </div>
 
-        {cv.photo && (
-          <div className="order-1 flex justify-start md:order-2 md:justify-end">
-            <Avatar className="size-24 md:size-32">
-              <Avatar.Image alt={cv.name} src={cv.photo} />
-              <Avatar.Fallback>{initials(cv.name)}</Avatar.Fallback>
-            </Avatar>
+        <div className="mt-6 space-y-2.5">
+          <Link
+            className="group inline-flex min-h-12 w-full items-center justify-between gap-4 rounded-full bg-foreground py-1.5 pl-4 pr-1.5 text-sm font-semibold text-background no-underline shadow-[0_16px_34px_rgba(0,0,0,0.18)] transition-transform duration-500 ease-[cubic-bezier(0.32,0.72,0,1)] hover:scale-[1.01] active:scale-[0.985]"
+            href={pdfPath}
+          >
+            <span className="inline-flex items-center gap-2">
+              <FilePdfIcon size={17} />
+              Download PDF
+            </span>
+            <span className="flex size-9 items-center justify-center rounded-full bg-background/12 text-background transition-transform duration-500 ease-[cubic-bezier(0.32,0.72,0,1)] group-hover:translate-x-1 group-hover:-translate-y-0.5">
+              <DownloadIcon size={17} />
+            </span>
+          </Link>
+
+          {cv.social_networks && cv.social_networks.length > 0 && (
+            <div className="grid grid-cols-1 gap-2">
+              {cv.social_networks.map(({ network, username }) => (
+                <Link
+                  key={network}
+                  className="group inline-flex min-h-11 items-center justify-between gap-3 rounded-full border border-border/75 bg-default/65 px-4 text-sm font-medium text-foreground no-underline transition-[background-color,border-color,transform] duration-500 ease-[cubic-bezier(0.32,0.72,0,1)] hover:-translate-y-0.5 hover:border-accent/40 hover:bg-default"
+                  href={buildSocialUrl(network, username)}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <span className="inline-flex items-center gap-2.5">
+                    <SocialIcon network={network} />
+                    {network}
+                  </span>
+                  <ArrowUpRightIcon
+                    className="text-muted transition-transform duration-500 ease-[cubic-bezier(0.32,0.72,0,1)] group-hover:translate-x-0.5 group-hover:-translate-y-0.5 group-hover:text-foreground"
+                    size={15}
+                  />
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {languages && languages.entries.length > 0 && (
+          <div className="mt-7 border-t border-border/70 pt-5">
+            <Typography
+              className="font-mono text-[11px] font-medium uppercase leading-4 tracking-[0.16em] text-muted"
+              type="body-xs"
+            >
+              Languages
+            </Typography>
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              {languages.entries.map((lang, index) => (
+                <Chip
+                  key={`lang-${index}-${lang.label}`}
+                  size="sm"
+                  variant="soft"
+                >
+                  {lang.details
+                    ? `${lang.label} · ${lang.details}`
+                    : lang.label}
+                </Chip>
+              ))}
+            </div>
           </div>
         )}
       </div>
-
-      {languages && languages.entries.length > 0 && (
-        <div className="mt-10 grid grid-cols-[auto_1fr] items-center gap-x-8 border-t border-border pt-6">
-          <Typography
-            className="text-xs font-semibold uppercase leading-4 tracking-wider text-muted"
-            type="body-xs"
-          >
-            Languages
-          </Typography>
-          <div className="flex flex-wrap gap-1.5">
-            {languages.entries.map((lang, index) => (
-              <Chip
-                key={`lang-${index}-${lang.label}`}
-                size="sm"
-                variant="soft"
-              >
-                {lang.details ? `${lang.label} · ${lang.details}` : lang.label}
-              </Chip>
-            ))}
-          </div>
-        </div>
-      )}
     </header>
   );
 }

--- a/src/components/ResumeSections/BulletSection.tsx
+++ b/src/components/ResumeSections/BulletSection.tsx
@@ -9,12 +9,14 @@ import { BulletList } from "@/components/shared";
 interface BulletSectionProps {
   entries: BulletEntry[] | undefined;
   sectionName: string;
+  sectionIndex: number;
   itemVariants: Variants;
 }
 
 export const BulletSection: FC<BulletSectionProps> = ({
   entries,
   sectionName,
+  sectionIndex,
   itemVariants,
 }) => {
   const { displayTitle } = getSectionConfig(sectionName);
@@ -22,7 +24,11 @@ export const BulletSection: FC<BulletSectionProps> = ({
   const items = entries?.map((entry) => entry.bullet) ?? [];
 
   return (
-    <SectionCard itemVariants={itemVariants} title={displayTitle}>
+    <SectionCard
+      index={sectionIndex}
+      itemVariants={itemVariants}
+      title={displayTitle}
+    >
       <BulletList items={items} />
     </SectionCard>
   );

--- a/src/components/ResumeSections/EducationSection.tsx
+++ b/src/components/ResumeSections/EducationSection.tsx
@@ -12,19 +12,25 @@ import { formatList } from "@/lib/utils";
 interface EducationSectionProps {
   entries: EducationEntry[] | undefined;
   sectionName: string;
+  sectionIndex: number;
   itemVariants: Variants;
 }
 
 export const EducationSection: FC<EducationSectionProps> = ({
   entries,
   sectionName,
+  sectionIndex,
   itemVariants,
 }) => {
   const { displayTitle } = getSectionConfig(sectionName);
 
   return (
-    <SectionCard itemVariants={itemVariants} title={displayTitle}>
-      <div className="divide-y divide-border">
+    <SectionCard
+      index={sectionIndex}
+      itemVariants={itemVariants}
+      title={displayTitle}
+    >
+      <div className="space-y-3">
         {entries?.map((edu, index) => (
           <ItemCard
             key={`${sectionName}-${edu.institution || "unknown"}-${index}`}
@@ -42,15 +48,15 @@ export const EducationSection: FC<EducationSectionProps> = ({
             <SummaryText text={edu.summary} />
 
             {edu.courses && edu.courses.length > 0 && (
-              <div className="border-l border-border pl-4">
+              <div className="border-l border-accent/40 pl-4">
                 <Typography
-                  className="mb-2 text-xs font-medium uppercase leading-4 tracking-wider text-muted"
+                  className="mb-2 font-mono text-[11px] font-medium uppercase leading-4 tracking-[0.12em] text-muted"
                   type="body-xs"
                 >
                   Coursework
                 </Typography>
                 <Typography
-                  className="text-sm leading-relaxed text-muted"
+                  className="text-sm leading-7 text-muted"
                   type="body-sm"
                 >
                   {formatList(edu.courses)}

--- a/src/components/ResumeSections/ExperienceSection.tsx
+++ b/src/components/ResumeSections/ExperienceSection.tsx
@@ -14,19 +14,25 @@ import {
 interface ExperienceSectionProps {
   entries: ExperienceEntry[] | undefined;
   sectionName: string;
+  sectionIndex: number;
   itemVariants: Variants;
 }
 
 export const ExperienceSection: FC<ExperienceSectionProps> = ({
   entries,
   sectionName,
+  sectionIndex,
   itemVariants,
 }) => {
   const { displayTitle } = getSectionConfig(sectionName);
 
   return (
-    <SectionCard itemVariants={itemVariants} title={displayTitle}>
-      <div className="divide-y divide-border">
+    <SectionCard
+      index={sectionIndex}
+      itemVariants={itemVariants}
+      title={displayTitle}
+    >
+      <div className="space-y-3">
         {entries?.map((entry, index) => (
           <ItemCard
             key={`${sectionName}-${entry.company || "unknown"}-${index}`}

--- a/src/components/ResumeSections/NormalSection.tsx
+++ b/src/components/ResumeSections/NormalSection.tsx
@@ -18,19 +18,25 @@ import { formatList } from "@/lib/utils";
 interface NormalSectionProps {
   entries: NormalEntry[] | undefined;
   sectionName: string;
+  sectionIndex: number;
   itemVariants: Variants;
 }
 
 export const NormalSection: FC<NormalSectionProps> = ({
   entries,
   sectionName,
+  sectionIndex,
   itemVariants,
 }) => {
   const { displayTitle } = getSectionConfig(sectionName);
 
   return (
-    <SectionCard itemVariants={itemVariants} title={displayTitle}>
-      <div className="divide-y divide-border">
+    <SectionCard
+      index={sectionIndex}
+      itemVariants={itemVariants}
+      title={displayTitle}
+    >
+      <div className="space-y-3">
         {entries?.map((entry, index) => {
           const metaLine = formatList([
             entry.entity ?? entry.issuer,
@@ -42,16 +48,19 @@ export const NormalSection: FC<NormalSectionProps> = ({
               <div className="mb-4 flex flex-col gap-1 md:flex-row md:items-baseline md:justify-between md:gap-6">
                 <div className="flex-1">
                   <Typography.Heading
-                    className="text-lg font-semibold tracking-normal text-foreground"
+                    className="text-xl font-semibold leading-snug tracking-normal text-foreground"
                     level={3}
                   >
-                    <ExternalLink className="text-foreground" url={entry.url}>
+                    <ExternalLink
+                      className="group text-foreground no-underline decoration-accent/50 underline-offset-4 hover:underline"
+                      url={entry.url}
+                    >
                       {entry.name}
                     </ExternalLink>
                   </Typography.Heading>
                   {metaLine && (
                     <Typography
-                      className="mt-1.5 text-xs leading-4 text-muted"
+                      className="mt-2 font-mono text-[11px] font-medium uppercase leading-4 tracking-[0.08em] text-muted"
                       type="body-xs"
                     >
                       {metaLine}
@@ -59,7 +68,7 @@ export const NormalSection: FC<NormalSectionProps> = ({
                   )}
                   {entry.roles && entry.roles.length > 0 && (
                     <Typography
-                      className="mt-0.5 text-sm leading-5 text-muted"
+                      className="mt-1 text-sm font-medium leading-6 text-muted"
                       type="body-sm"
                     >
                       {formatList(entry.roles)}
@@ -68,6 +77,7 @@ export const NormalSection: FC<NormalSectionProps> = ({
                 </div>
                 <div className="shrink-0">
                   <DateRange
+                    className="rounded-full border border-border/70 bg-default/65 px-2.5 py-1"
                     endDate={entry.date ?? entry.end_date}
                     startDate={entry.start_date}
                   />

--- a/src/components/ResumeSections/OneLineSection.tsx
+++ b/src/components/ResumeSections/OneLineSection.tsx
@@ -6,20 +6,19 @@ import { Chip, Typography } from "@heroui/react";
 
 import { SectionCard, getSectionConfig } from "./SectionCard";
 
+import { ItemCard } from "@/components/shared";
+
 interface OneLineSectionProps {
   entries: OneLineEntry[] | undefined;
   sectionName: string;
+  sectionIndex: number;
   itemVariants: Variants;
 }
 
-/**
- * Layout for OneLineEntry sections.
- * - With keywords (Skills/Interests): label + level + keyword chips
- * - Without keywords (Languages-like): compact label · details pairs
- */
 export const OneLineSection: FC<OneLineSectionProps> = ({
   entries,
   sectionName,
+  sectionIndex,
   itemVariants,
 }) => {
   const { displayTitle } = getSectionConfig(sectionName);
@@ -29,13 +28,16 @@ export const OneLineSection: FC<OneLineSectionProps> = ({
   );
 
   return (
-    <SectionCard itemVariants={itemVariants} title={displayTitle}>
+    <SectionCard
+      index={sectionIndex}
+      itemVariants={itemVariants}
+      title={displayTitle}
+    >
       {hasKeywords ? (
-        <div className="divide-y divide-border">
+        <div className="space-y-3">
           {entries?.map((entry, index) => (
-            <div
+            <ItemCard
               key={`${sectionName}-${entry.label || "unknown"}-${index}`}
-              className="py-6"
             >
               <div className="mb-3 flex items-baseline justify-between gap-4">
                 <Typography.Heading
@@ -46,7 +48,7 @@ export const OneLineSection: FC<OneLineSectionProps> = ({
                 </Typography.Heading>
                 {entry.details && (
                   <Typography
-                    className="shrink-0 text-xs leading-4 text-muted"
+                    className="shrink-0 rounded-full border border-border/70 bg-default/65 px-2.5 py-1 font-mono text-[11px] font-medium uppercase leading-4 tracking-[0.08em] text-muted"
                     type="body-xs"
                   >
                     {entry.details}
@@ -62,7 +64,7 @@ export const OneLineSection: FC<OneLineSectionProps> = ({
                   ))}
                 </div>
               )}
-            </div>
+            </ItemCard>
           ))}
         </div>
       ) : (
@@ -70,17 +72,17 @@ export const OneLineSection: FC<OneLineSectionProps> = ({
           {entries?.map((entry, index) => (
             <div
               key={`${sectionName}-${entry.label || "unknown"}-${index}`}
-              className="flex items-baseline justify-between gap-3 border-b border-border py-3"
+              className="flex items-baseline justify-between gap-3 rounded-2xl border border-border/70 bg-surface/58 px-4 py-3"
             >
               <Typography
-                className="text-sm leading-5 text-foreground"
+                className="text-sm font-medium leading-5 text-foreground"
                 type="body-sm"
               >
                 {entry.label}
               </Typography>
               {entry.details && (
                 <Typography
-                  className="text-xs leading-4 text-muted"
+                  className="font-mono text-[11px] font-medium uppercase leading-4 tracking-[0.08em] text-muted"
                   type="body-xs"
                 >
                   {entry.details}

--- a/src/components/ResumeSections/PublicationSection.tsx
+++ b/src/components/ResumeSections/PublicationSection.tsx
@@ -13,19 +13,25 @@ import { formatList } from "@/lib/utils";
 interface PublicationSectionProps {
   entries: PublicationEntry[] | undefined;
   sectionName: string;
+  sectionIndex: number;
   itemVariants: Variants;
 }
 
 export const PublicationSection: FC<PublicationSectionProps> = ({
   entries,
   sectionName,
+  sectionIndex,
   itemVariants,
 }) => {
   const { displayTitle } = getSectionConfig(sectionName);
 
   return (
-    <SectionCard itemVariants={itemVariants} title={displayTitle}>
-      <div className="divide-y divide-border">
+    <SectionCard
+      index={sectionIndex}
+      itemVariants={itemVariants}
+      title={displayTitle}
+    >
+      <div className="space-y-3">
         {entries?.map((pub, index) => {
           const url =
             pub.url ?? (pub.doi ? `https://doi.org/${pub.doi}` : undefined);
@@ -33,16 +39,16 @@ export const PublicationSection: FC<PublicationSectionProps> = ({
 
           return (
             <ItemCard key={`${sectionName}-${pub.title || "unknown"}-${index}`}>
-              <div className="grid grid-cols-[auto_1fr_auto] items-baseline gap-4 md:gap-6">
+              <div className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-4 md:grid-cols-[auto_minmax(0,1fr)_auto] md:gap-6">
                 <Typography
-                  className="font-mono text-xs leading-4 text-muted"
+                  className="rounded-full border border-border/70 bg-default/65 px-2.5 py-1 font-mono text-[11px] font-medium leading-4 text-muted"
                   type="body-xs"
                 >
                   {String(index + 1).padStart(2, "0")}
                 </Typography>
                 <div>
                   <Typography.Heading
-                    className="text-lg font-semibold leading-snug tracking-normal text-foreground"
+                    className="text-xl font-semibold leading-snug tracking-normal text-foreground"
                     level={3}
                   >
                     <ExternalLink
@@ -55,7 +61,7 @@ export const PublicationSection: FC<PublicationSectionProps> = ({
                   </Typography.Heading>
                   {meta && (
                     <Typography
-                      className="mt-2 text-xs leading-4 text-muted"
+                      className="mt-2 font-mono text-[11px] font-medium uppercase leading-4 tracking-[0.08em] text-muted"
                       type="body-xs"
                     >
                       {meta}
@@ -63,7 +69,7 @@ export const PublicationSection: FC<PublicationSectionProps> = ({
                   )}
                   {pub.authors && pub.authors.length > 0 && (
                     <Typography
-                      className="mt-3 text-sm leading-5 text-muted"
+                      className="mt-3 text-sm leading-6 text-muted"
                       type="body-sm"
                     >
                       {pub.authors.map((author, i) => {
@@ -95,7 +101,7 @@ export const PublicationSection: FC<PublicationSectionProps> = ({
                         ? `Open publication: ${pub.title}`
                         : "Open publication"
                     }
-                    className="mt-1"
+                    className="mt-1 hidden rounded-full border border-border/70 bg-default/65 p-2 text-foreground transition-[background-color,border-color,transform] duration-500 ease-[cubic-bezier(0.32,0.72,0,1)] hover:-translate-y-0.5 hover:border-accent/40 hover:bg-default md:inline-flex"
                     href={url}
                     rel="noopener noreferrer"
                     target="_blank"

--- a/src/components/ResumeSections/ResumeSectionRenderer.tsx
+++ b/src/components/ResumeSections/ResumeSectionRenderer.tsx
@@ -22,12 +22,14 @@ import { detectEntryType } from "@/utils/resume";
 interface ResumeSectionRendererProps {
   entries: Entry[] | undefined;
   itemVariants: Variants;
+  sectionIndex: number;
   sectionName: string;
 }
 
 export function ResumeSectionRenderer({
   entries,
   itemVariants,
+  sectionIndex,
   sectionName,
 }: ResumeSectionRendererProps) {
   if (!entries || entries.length === 0) {
@@ -42,6 +44,7 @@ export function ResumeSectionRenderer({
         <ExperienceSection
           entries={entries as ExperienceEntry[]}
           itemVariants={itemVariants}
+          sectionIndex={sectionIndex}
           sectionName={sectionName}
         />
       );
@@ -50,6 +53,7 @@ export function ResumeSectionRenderer({
         <EducationSection
           entries={entries as EducationEntry[]}
           itemVariants={itemVariants}
+          sectionIndex={sectionIndex}
           sectionName={sectionName}
         />
       );
@@ -58,6 +62,7 @@ export function ResumeSectionRenderer({
         <PublicationSection
           entries={entries as PublicationEntry[]}
           itemVariants={itemVariants}
+          sectionIndex={sectionIndex}
           sectionName={sectionName}
         />
       );
@@ -66,6 +71,7 @@ export function ResumeSectionRenderer({
         <NormalSection
           entries={entries as NormalEntry[]}
           itemVariants={itemVariants}
+          sectionIndex={sectionIndex}
           sectionName={sectionName}
         />
       );
@@ -74,6 +80,7 @@ export function ResumeSectionRenderer({
         <OneLineSection
           entries={entries as OneLineEntry[]}
           itemVariants={itemVariants}
+          sectionIndex={sectionIndex}
           sectionName={sectionName}
         />
       );
@@ -82,6 +89,7 @@ export function ResumeSectionRenderer({
         <BulletSection
           entries={entries as BulletEntry[]}
           itemVariants={itemVariants}
+          sectionIndex={sectionIndex}
           sectionName={sectionName}
         />
       );
@@ -90,6 +98,7 @@ export function ResumeSectionRenderer({
         <TextSection
           entries={entries as string[]}
           itemVariants={itemVariants}
+          sectionIndex={sectionIndex}
           sectionName={sectionName}
         />
       );

--- a/src/components/ResumeSections/SectionCard.tsx
+++ b/src/components/ResumeSections/SectionCard.tsx
@@ -2,33 +2,35 @@ import type { FC, ReactNode } from "react";
 import type { Variants } from "framer-motion";
 
 import { m } from "framer-motion";
-import { Separator, Typography } from "@heroui/react";
+import { Typography } from "@heroui/react";
 
 interface SectionCardProps {
   title: string;
+  index: number;
   itemVariants: Variants;
   children: ReactNode;
 }
 
-/**
- * Section wrapper: an uppercase heading (HeroUI Typography rendered as h2)
- * followed by a full-width HeroUI Separator, then content.
- */
 export const SectionCard: FC<SectionCardProps> = ({
   title,
+  index,
   itemVariants,
   children,
 }) => {
   return (
-    <m.section className="scroll-mt-24" variants={itemVariants}>
-      <div className="mb-8 flex items-center gap-4">
-        <Typography.Heading
-          className="text-xs font-semibold uppercase tracking-wider text-muted"
-          level={2}
-        >
-          {title}
-        </Typography.Heading>
-        <Separator className="flex-1" />
+    <m.section className="scroll-mt-28" variants={itemVariants}>
+      <div className="mb-5 grid grid-cols-[3rem_1fr] items-start gap-4">
+        <div className="rounded-full border border-border/70 bg-default/65 px-2.5 py-1 text-center font-mono text-[11px] font-medium uppercase tracking-[0.08em] text-muted">
+          {String(index).padStart(2, "0")}
+        </div>
+        <div className="border-t border-border/80 pt-3">
+          <Typography.Heading
+            className="text-sm font-semibold uppercase tracking-[0.16em] text-foreground"
+            level={2}
+          >
+            {title}
+          </Typography.Heading>
+        </div>
       </div>
       <div>{children}</div>
     </m.section>

--- a/src/components/ResumeSections/TextSection.tsx
+++ b/src/components/ResumeSections/TextSection.tsx
@@ -8,23 +8,29 @@ import { SectionCard, getSectionConfig } from "./SectionCard";
 interface TextSectionProps {
   entries: string[] | undefined;
   sectionName: string;
+  sectionIndex: number;
   itemVariants: Variants;
 }
 
 export const TextSection: FC<TextSectionProps> = ({
   entries,
   sectionName,
+  sectionIndex,
   itemVariants,
 }) => {
   const { displayTitle } = getSectionConfig(sectionName);
 
   return (
-    <SectionCard itemVariants={itemVariants} title={displayTitle}>
+    <SectionCard
+      index={sectionIndex}
+      itemVariants={itemVariants}
+      title={displayTitle}
+    >
       <div className="max-w-3xl space-y-4">
         {entries?.map((text, index) => (
           <Typography
             key={`${sectionName}-text-${index}`}
-            className="text-sm leading-relaxed text-muted"
+            className="text-sm leading-7 text-muted"
             type="body-sm"
           >
             {text}

--- a/src/components/Threads/Threads.tsx
+++ b/src/components/Threads/Threads.tsx
@@ -7,6 +7,19 @@ type ThreadsProps = Omit<HTMLAttributes<HTMLDivElement>, "color"> & {
   distance?: number;
 };
 
+function canCreateWebGLContext(): boolean {
+  try {
+    const canvas = document.createElement("canvas");
+    const gl = canvas.getContext("webgl2") ?? canvas.getContext("webgl");
+
+    gl?.getExtension("WEBGL_lose_context")?.loseContext();
+
+    return !!gl;
+  } catch {
+    return false;
+  }
+}
+
 const vertexShader = `
 attribute vec2 position;
 attribute vec2 uv;
@@ -138,7 +151,26 @@ export default function Threads({
     if (!containerRef.current) return;
     const container = containerRef.current;
 
-    const renderer = new Renderer({ alpha: true });
+    if (!canCreateWebGLContext()) {
+      if (import.meta.env.DEV) {
+        console.warn("[Threads] WebGL is not available; skipping background.");
+      }
+
+      return;
+    }
+
+    let renderer: Renderer;
+
+    try {
+      renderer = new Renderer({ alpha: true });
+    } catch (error) {
+      if (import.meta.env.DEV) {
+        console.warn("[Threads] Failed to initialize WebGL renderer.", error);
+      }
+
+      return;
+    }
+
     const gl = renderer.gl;
 
     gl.clearColor(0, 0, 0, 0);

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,6 +1,5 @@
 import { useSyncExternalStore } from "react";
 import { Link, useLocation } from "react-router-dom";
-import { m } from "framer-motion";
 import { Button, Separator, useTheme } from "@heroui/react";
 
 import { MoonIcon, SunIcon } from "@/components/shared";
@@ -25,17 +24,14 @@ export const Navbar = () => {
   const isDark = resolvedTheme !== "light";
 
   return (
-    <header className="pointer-events-none fixed inset-x-0 top-0 z-50 flex justify-center px-4 pt-4 sm:pt-5">
-      <m.nav
-        animate={{
-          paddingTop: isScrolled ? 4 : 6,
-          paddingBottom: isScrolled ? 4 : 6,
-        }}
+    <header className="pointer-events-none fixed inset-x-0 top-0 z-30 flex justify-center px-4 pt-4 sm:pt-5">
+      <nav
         className={cn(
-          "pointer-events-auto flex items-center gap-1 rounded-full border border-border bg-surface/70 backdrop-blur-xl transition-shadow duration-300",
-          isScrolled ? "shadow-lg" : "shadow-none",
+          "pointer-events-auto flex items-center gap-1 rounded-full border border-border/75 bg-background/82 p-1 shadow-[0_14px_40px_rgba(0,0,0,0.10)] backdrop-blur-xl transition-[background-color,border-color,box-shadow] duration-500 ease-[cubic-bezier(0.32,0.72,0,1)]",
+          isScrolled
+            ? "border-border bg-background/92 shadow-[0_18px_50px_rgba(0,0,0,0.16)]"
+            : "shadow-[0_10px_28px_rgba(0,0,0,0.08)]",
         )}
-        transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
       >
         <div className="relative flex items-center gap-0.5 pl-1">
           {tabs.map((tab) => {
@@ -45,7 +41,7 @@ export const Navbar = () => {
               <Link
                 key={tab.href}
                 className={cn(
-                  "relative rounded-full px-3 py-1.5 text-sm font-medium transition-colors",
+                  "relative rounded-full px-3.5 py-2 text-sm font-medium transition-colors duration-500 ease-[cubic-bezier(0.32,0.72,0,1)]",
                   isActive
                     ? "text-foreground"
                     : "text-muted hover:text-foreground",
@@ -53,14 +49,9 @@ export const Navbar = () => {
                 to={tab.href}
               >
                 {isActive && (
-                  <m.span
-                    className="absolute inset-0 rounded-full bg-default"
-                    layoutId="active-tab-pill"
-                    transition={{
-                      type: "spring",
-                      stiffness: 400,
-                      damping: 32,
-                    }}
+                  <span
+                    aria-hidden="true"
+                    className="absolute inset-0 rounded-full bg-default shadow-[0_1px_0_rgba(255,255,255,0.08)_inset]"
                   />
                 )}
                 <span className="relative z-10">{tab.label}</span>
@@ -75,7 +66,7 @@ export const Navbar = () => {
           <Button
             isIconOnly
             aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
-            className="rounded-full"
+            className="rounded-full transition-transform duration-500 ease-[cubic-bezier(0.32,0.72,0,1)] active:scale-95"
             size="sm"
             variant="ghost"
             onPress={() => setTheme(isDark ? "light" : "dark")}
@@ -83,7 +74,7 @@ export const Navbar = () => {
             {isDark ? <SunIcon /> : <MoonIcon />}
           </Button>
         </div>
-      </m.nav>
+      </nav>
     </header>
   );
 };

--- a/src/components/shared/BulletList.tsx
+++ b/src/components/shared/BulletList.tsx
@@ -15,16 +15,11 @@ export const BulletList: FC<BulletListProps> = ({ items, className = "" }) => {
   }
 
   return (
-    <ul
-      className={cn("list-disc space-y-2 pl-5 marker:text-muted/60", className)}
-    >
+    <ul className={cn("space-y-2.5", className)}>
       {items.map((item, index) => (
-        // text-sm on the <li> keeps the ::marker sized to the body text.
-        <li key={index} className="text-sm leading-relaxed text-muted">
-          <Typography
-            className="text-sm leading-relaxed text-muted"
-            type="body-sm"
-          >
+        <li key={index} className="grid grid-cols-[0.65rem_1fr] gap-3">
+          <span className="mt-2 size-1.5 rounded-full bg-accent/75" />
+          <Typography className="text-sm leading-7 text-muted" type="body-sm">
             {item}
           </Typography>
         </li>

--- a/src/components/shared/DateRange.tsx
+++ b/src/components/shared/DateRange.tsx
@@ -21,13 +21,16 @@ export const DateRange: FC<DateRangeProps> = ({
 
   let text = "";
 
-  if (startDate && endDate) text = `${startDate} — ${endDate}`;
+  if (startDate && endDate) text = `${startDate} to ${endDate}`;
   else if (startDate) text = startDate;
   else if (endDate) text = endDate;
 
   return (
     <Typography
-      className={cn("text-xs leading-4 text-muted", className)}
+      className={cn(
+        "font-mono text-[11px] font-medium uppercase leading-4 tracking-[0.08em] text-muted",
+        className,
+      )}
       type="body-xs"
     >
       {text}

--- a/src/components/shared/EntryHeader.tsx
+++ b/src/components/shared/EntryHeader.tsx
@@ -17,11 +17,6 @@ interface EntryHeaderProps {
   className?: string;
 }
 
-/**
- * Shared header row for Experience/Education-style entries:
- * a linked title with optional subtitle on the left, and a
- * date range with optional meta (location, grade) on the right.
- */
 export const EntryHeader: FC<EntryHeaderProps> = ({
   title,
   url,
@@ -33,35 +28,40 @@ export const EntryHeader: FC<EntryHeaderProps> = ({
 }) => (
   <div
     className={cn(
-      "flex flex-col gap-1 md:flex-row md:items-baseline md:justify-between md:gap-6",
+      "flex flex-col gap-3 md:flex-row md:items-start md:justify-between md:gap-6",
       className,
     )}
   >
     <div className="flex-1">
       <Typography.Heading
-        className="text-lg font-semibold tracking-normal text-foreground"
+        className="text-xl font-semibold leading-snug tracking-normal text-foreground"
         level={3}
       >
-        <ExternalLink className="text-foreground" showIcon={false} url={url}>
+        <ExternalLink
+          className="text-foreground no-underline decoration-accent/50 underline-offset-4 hover:underline"
+          showIcon={false}
+          url={url}
+        >
           {title}
         </ExternalLink>
       </Typography.Heading>
       {subtitle && (
         <Typography
-          className="mt-0.5 text-sm leading-5 text-muted"
+          className="mt-1 text-sm font-medium leading-6 text-muted"
           type="body-sm"
         >
           {subtitle}
         </Typography>
       )}
     </div>
-    <div className="flex shrink-0 flex-col items-start md:items-end">
-      <DateRange endDate={endDate} startDate={startDate} />
+    <div className="flex shrink-0 flex-col items-start gap-1 md:items-end">
+      <DateRange
+        className="rounded-full border border-border/70 bg-default/65 px-2.5 py-1"
+        endDate={endDate}
+        startDate={startDate}
+      />
       {rightMeta && (
-        <Typography
-          className="mt-1 text-xs leading-4 text-muted"
-          type="body-xs"
-        >
+        <Typography className="text-xs leading-5 text-muted" type="body-xs">
           {rightMeta}
         </Typography>
       )}

--- a/src/components/shared/ExternalLink.tsx
+++ b/src/components/shared/ExternalLink.tsx
@@ -31,7 +31,9 @@ export const ExternalLink: FC<ExternalLinkProps> = ({
       target="_blank"
     >
       {children}
-      {showIcon && <Link.Icon />}
+      {showIcon && (
+        <Link.Icon className="transition-transform duration-500 ease-[cubic-bezier(0.32,0.72,0,1)] group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+      )}
     </Link>
   );
 };

--- a/src/components/shared/ItemCard.tsx
+++ b/src/components/shared/ItemCard.tsx
@@ -2,10 +2,6 @@ import type { FC, ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
 
-/**
- * Reusable entry container for resume items.
- * A divided-list row with a subtle hover surface.
- */
 interface ItemCardProps {
   children: ReactNode;
   className?: string;
@@ -14,7 +10,7 @@ interface ItemCardProps {
 export const ItemCard: FC<ItemCardProps> = ({ children, className = "" }) => (
   <div
     className={cn(
-      "group -mx-4 rounded-lg px-4 py-6 transition-colors duration-200 hover:bg-default/40",
+      "group rounded-2xl border border-border/70 bg-surface/58 p-5 shadow-[0_1px_0_rgba(255,255,255,0.08)_inset] transition-[background-color,border-color,transform] duration-500 ease-[cubic-bezier(0.32,0.72,0,1)] hover:-translate-y-0.5 hover:border-accent/35 hover:bg-surface/86 sm:p-6",
       className,
     )}
   >

--- a/src/components/shared/SummaryText.tsx
+++ b/src/components/shared/SummaryText.tsx
@@ -24,7 +24,7 @@ export const SummaryText: FC<SummaryTextProps> = ({
 
   return (
     <Typography
-      className={cn("max-w-3xl text-sm leading-relaxed text-muted", className)}
+      className={cn("max-w-[72ch] text-sm leading-7 text-muted", className)}
       type="body-sm"
     >
       {text}

--- a/src/components/shared/icons.tsx
+++ b/src/components/shared/icons.tsx
@@ -1,91 +1,79 @@
-import type { SVGProps } from "react";
+import type { IconProps } from "@phosphor-icons/react";
 
-type IconProps = SVGProps<SVGSVGElement> & {
-  size?: number;
-};
+import {
+  ArrowRightIcon as PhosphorArrowRightIcon,
+  ArrowUpRightIcon as PhosphorArrowUpRightIcon,
+  BriefcaseIcon as PhosphorBriefcaseIcon,
+  CircuitryIcon as PhosphorCircuitryIcon,
+  CodeIcon as PhosphorCodeIcon,
+  DownloadSimpleIcon as PhosphorDownloadSimpleIcon,
+  EnvelopeSimpleIcon as PhosphorEnvelopeSimpleIcon,
+  FilePdfIcon as PhosphorFilePdfIcon,
+  GithubLogoIcon as PhosphorGithubLogoIcon,
+  LinkedinLogoIcon as PhosphorLinkedinLogoIcon,
+  MapPinIcon as PhosphorMapPinIcon,
+  MoonIcon as PhosphorMoonIcon,
+  SparkleIcon as PhosphorSparkleIcon,
+  SunIcon as PhosphorSunIcon,
+} from "@phosphor-icons/react";
+
+const iconDefaults = {
+  "aria-hidden": true,
+  "weight": "regular",
+} as const;
 
 export const ArrowUpRightIcon = ({ size = 14, ...props }: IconProps) => (
-  <svg
-    aria-hidden="true"
-    fill="none"
-    height={size}
-    stroke="currentColor"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    strokeWidth="1.5"
-    viewBox="0 0 24 24"
-    width={size}
-    {...props}
-  >
-    <path d="M7 17L17 7M7 7h10v10" />
-  </svg>
+  <PhosphorArrowUpRightIcon size={size} {...iconDefaults} {...props} />
 );
 
 export const ArrowRightIcon = ({ size = 14, ...props }: IconProps) => (
-  <svg
-    aria-hidden="true"
-    fill="none"
-    height={size}
-    stroke="currentColor"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    strokeWidth="1.75"
-    viewBox="0 0 24 24"
-    width={size}
-    {...props}
-  >
-    <path d="M5 12h14M13 5l7 7-7 7" />
-  </svg>
+  <PhosphorArrowRightIcon size={size} {...iconDefaults} {...props} />
 );
 
 export const GitHubIcon = ({ size = 16, ...props }: IconProps) => (
-  <svg
-    aria-hidden="true"
-    fill="currentColor"
-    height={size}
-    viewBox="0 0 24 24"
-    width={size}
-    {...props}
-  >
-    <path
-      clipRule="evenodd"
-      d="M12.026 2c-5.509 0-9.974 4.465-9.974 9.974 0 4.406 2.857 8.145 6.821 9.465.499.09.679-.217.679-.481 0-.237-.008-.865-.011-1.696-2.775.602-3.361-1.338-3.361-1.338-.452-1.152-1.107-1.459-1.107-1.459-.905-.619.069-.605.069-.605 1.002.07 1.527 1.028 1.527 1.028.89 1.524 2.336 1.084 2.902.829.091-.645.351-1.085.635-1.334-2.214-.251-4.542-1.107-4.542-4.93 0-1.087.389-1.979 1.024-2.675-.101-.253-.446-1.268.099-2.64 0 0 .837-.269 2.742 1.021a9.582 9.582 0 0 1 2.496-.336 9.554 9.554 0 0 1 2.496.336c1.906-1.291 2.742-1.021 2.742-1.021.545 1.372.203 2.387.099 2.64.64.696 1.024 1.587 1.024 2.675 0 3.833-2.33 4.675-4.552 4.922.355.308.675.916.675 1.846 0 1.334-.012 2.41-.012 2.737 0 .267.178.577.687.479C19.146 20.115 22 16.379 22 11.974 22 6.465 17.535 2 12.026 2z"
-      fillRule="evenodd"
-    />
-  </svg>
+  <PhosphorGithubLogoIcon size={size} {...iconDefaults} {...props} />
+);
+
+export const LinkedInIcon = ({ size = 16, ...props }: IconProps) => (
+  <PhosphorLinkedinLogoIcon size={size} {...iconDefaults} {...props} />
 );
 
 export const SunIcon = ({ size = 18, ...props }: IconProps) => (
-  <svg
-    aria-hidden="true"
-    fill="none"
-    height={size}
-    stroke="currentColor"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    strokeWidth="1.75"
-    viewBox="0 0 24 24"
-    width={size}
-    {...props}
-  >
-    <circle cx="12" cy="12" r="4" />
-    <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
-  </svg>
+  <PhosphorSunIcon size={size} {...iconDefaults} {...props} />
 );
 
 export const MoonIcon = ({ size = 18, ...props }: IconProps) => (
-  <svg
-    aria-hidden="true"
-    fill="none"
-    height={size}
-    stroke="currentColor"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    strokeWidth="1.75"
-    viewBox="0 0 24 24"
-    width={size}
-    {...props}
-  >
-    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-  </svg>
+  <PhosphorMoonIcon size={size} {...iconDefaults} {...props} />
+);
+
+export const DownloadIcon = ({ size = 16, ...props }: IconProps) => (
+  <PhosphorDownloadSimpleIcon size={size} {...iconDefaults} {...props} />
+);
+
+export const MailIcon = ({ size = 16, ...props }: IconProps) => (
+  <PhosphorEnvelopeSimpleIcon size={size} {...iconDefaults} {...props} />
+);
+
+export const MapPinIcon = ({ size = 16, ...props }: IconProps) => (
+  <PhosphorMapPinIcon size={size} {...iconDefaults} {...props} />
+);
+
+export const FilePdfIcon = ({ size = 16, ...props }: IconProps) => (
+  <PhosphorFilePdfIcon size={size} {...iconDefaults} {...props} />
+);
+
+export const BriefcaseIcon = ({ size = 16, ...props }: IconProps) => (
+  <PhosphorBriefcaseIcon size={size} {...iconDefaults} {...props} />
+);
+
+export const CodeIcon = ({ size = 16, ...props }: IconProps) => (
+  <PhosphorCodeIcon size={size} {...iconDefaults} {...props} />
+);
+
+export const CircuitryIcon = ({ size = 16, ...props }: IconProps) => (
+  <PhosphorCircuitryIcon size={size} {...iconDefaults} {...props} />
+);
+
+export const SparkleIcon = ({ size = 16, ...props }: IconProps) => (
+  <PhosphorSparkleIcon size={size} {...iconDefaults} {...props} />
 );

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -7,7 +7,16 @@ export { EntryHeader } from "./EntryHeader";
 export {
   ArrowRightIcon,
   ArrowUpRightIcon,
+  BriefcaseIcon,
+  CircuitryIcon,
+  CodeIcon,
+  DownloadIcon,
+  FilePdfIcon,
   GitHubIcon,
+  LinkedInIcon,
+  MailIcon,
+  MapPinIcon,
   MoonIcon,
+  SparkleIcon,
   SunIcon,
 } from "./icons";

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -13,6 +13,19 @@ const navItems = (() => {
 
 export const siteConfig = {
   navItems,
+  profile: {
+    displayName: "Wei Cheng Lee",
+    handle: "Mai",
+    role: "Firmware systems engineer",
+    summary:
+      "Building trusted firmware, pre-silicon validation, and AI-assisted semiconductor systems across Pixel SoCs and EDA research.",
+    location: "Hsinchu, Taiwan",
+    focusAreas: [
+      "Trusted Firmware-A",
+      "Pre-Silicon Validation",
+      "AI for Semiconductor Design",
+    ],
+  },
   links: {
     github: "https://github.com/Mai0313",
   },

--- a/src/layouts/default.tsx
+++ b/src/layouts/default.tsx
@@ -4,9 +4,9 @@ import { Navbar } from "@/components/navbar";
 
 export default function DefaultLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="relative flex min-h-screen flex-col bg-background text-foreground">
+    <div className="premium-shell relative flex min-h-[100dvh] flex-col bg-background text-foreground">
       <Navbar />
-      <main className="flex-grow">{children}</main>
+      <main className="relative z-0 flex-grow">{children}</main>
     </div>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,8 @@ import App from "./App.tsx";
 import ErrorBoundary from "./components/ErrorBoundary.tsx";
 
 import { getBasename } from "@/utils/pathUtils";
+import "@fontsource-variable/geist";
+import "@fontsource-variable/geist-mono";
 import "@/styles/globals.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,90 +2,239 @@ import type { ComponentPropsWithRef } from "react";
 
 import { lazy, Suspense } from "react";
 import { Link as RouterLink } from "react-router-dom";
+import { m } from "framer-motion";
 import { Link, Typography } from "@heroui/react";
 
 import DecryptedText from "@/components/DecryptedText/DecryptedText";
 import {
   ArrowRightIcon,
   ArrowUpRightIcon,
+  BriefcaseIcon,
+  CircuitryIcon,
+  CodeIcon,
   GitHubIcon,
 } from "@/components/shared";
 import DefaultLayout from "@/layouts/default";
 import { siteConfig } from "@/config/site";
-import { env, envHelpers } from "@/utils/env";
+import { envHelpers } from "@/utils/env";
 
 const Threads = lazy(() => import("@/components/Threads/Threads"));
 
-const THREADS_COLOR: [number, number, number] = [1, 1, 1];
+const THREADS_COLOR: [number, number, number] = [0.72, 0.95, 0.82];
+
+const impactItems = [
+  { label: "Pixel firmware", value: "TF-A / RF-A" },
+  { label: "C2 suspend latency", value: "14% cut" },
+  { label: "Peer-reviewed papers", value: "3" },
+];
+
+const focusItems = [
+  {
+    icon: CircuitryIcon,
+    label: "Trusted firmware",
+    detail: "Secure low-power paths and silicon bringup.",
+  },
+  {
+    icon: BriefcaseIcon,
+    label: "Pre-silicon validation",
+    detail: "Baremetal tests that unblock platform readiness.",
+  },
+  {
+    icon: CodeIcon,
+    label: "AI for EDA",
+    detail: "Physics-aware modeling and multi-agent design flows.",
+  },
+];
 
 export default function IndexPage() {
   const resumeAvailable = envHelpers.isResumeFileAvailable();
 
   return (
     <DefaultLayout>
-      {/* ────── Hero ────── */}
-      <section className="relative flex min-h-screen items-center overflow-hidden">
+      <section className="relative flex min-h-[100dvh] items-center overflow-hidden px-4 pb-20 pt-32 sm:px-6 sm:pt-40">
         <div
           aria-hidden="true"
-          className="pointer-events-none absolute inset-0 opacity-[0.28]"
+          className="pointer-events-none absolute inset-0 opacity-[0.18] dark:opacity-[0.24]"
         >
           <Suspense fallback={null}>
-            <Threads amplitude={1.4} color={THREADS_COLOR} distance={0.25} />
+            <Threads amplitude={0.9} color={THREADS_COLOR} distance={0.28} />
           </Suspense>
         </div>
         <div
           aria-hidden="true"
-          className="pointer-events-none absolute inset-x-0 bottom-0 h-60 bg-gradient-to-b from-transparent to-background"
+          className="pointer-events-none absolute inset-x-0 bottom-0 h-72 bg-gradient-to-b from-transparent to-background"
         />
 
-        <div className="relative z-10 mx-auto w-full max-w-6xl px-6 pb-24 pt-32 sm:pt-40">
-          <Typography.Heading
-            className="mb-12 font-bold leading-[1.02] tracking-tight"
-            level={1}
-            style={{ fontSize: "clamp(3.25rem, 10vw, 7rem)" }}
+        <m.div
+          animate="visible"
+          className="relative z-10 mx-auto grid w-full max-w-7xl grid-cols-1 gap-12 lg:grid-cols-[minmax(0,1fr)_420px] lg:items-end"
+          initial="hidden"
+          variants={{
+            hidden: { opacity: 0 },
+            visible: {
+              opacity: 1,
+              transition: { staggerChildren: 0.1 },
+            },
+          }}
+        >
+          <m.div
+            variants={{
+              hidden: { opacity: 0, y: 28 },
+              visible: {
+                opacity: 1,
+                y: 0,
+                transition: { duration: 0.75, ease: [0.32, 0.72, 0, 1] },
+              },
+            }}
           >
-            <DecryptedText
-              className="text-foreground"
-              encryptedClassName="text-muted/60"
-              revealDirection="start"
-              speed={55}
-              text={env.WEBSITE_TITLE}
-            />
-          </Typography.Heading>
+            <div className="mb-8 inline-flex items-center gap-2 rounded-full border border-border/70 bg-surface/70 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.2em] text-muted shadow-[0_1px_0_rgba(255,255,255,0.08)_inset]">
+              <span className="size-1.5 rounded-full bg-accent" />
+              {siteConfig.profile.handle} Portfolio
+            </div>
 
-          <div className="flex flex-wrap items-center gap-3">
-            {resumeAvailable && (
-              <Link
-                className="button button--primary gap-2"
-                href="/resume"
-                render={(props) => {
-                  // Drop the placeholder href so RouterLink fully owns the
-                  // basename-aware href it computes from `to`.
-                  const anchorProps = {
-                    ...(props as ComponentPropsWithRef<"a">),
-                  };
-
-                  delete anchorProps.href;
-
-                  return <RouterLink {...anchorProps} to="/resume" />;
-                }}
-              >
-                View Resume
-                <ArrowRightIcon />
-              </Link>
-            )}
-            <Link
-              className="button button--outline gap-2"
-              href={siteConfig.links.github}
-              rel="noopener noreferrer"
-              target="_blank"
+            <Typography.Heading
+              className="max-w-4xl text-balance text-5xl font-semibold leading-[0.98] tracking-normal text-foreground sm:text-6xl lg:text-7xl"
+              level={1}
             >
-              <GitHubIcon />
-              GitHub
-              <ArrowUpRightIcon size={16} />
-            </Link>
-          </div>
-        </div>
+              <DecryptedText
+                className="text-foreground"
+                encryptedClassName="text-muted/55"
+                revealDirection="start"
+                speed={48}
+                text={siteConfig.profile.displayName}
+              />
+            </Typography.Heading>
+
+            <Typography
+              className="mt-7 max-w-2xl text-lg leading-8 text-muted sm:text-xl sm:leading-9"
+              type="body"
+            >
+              {siteConfig.profile.summary}
+            </Typography>
+
+            <div className="mt-10 flex flex-wrap items-center gap-3">
+              {resumeAvailable && (
+                <Link
+                  className="group inline-flex min-h-12 items-center gap-4 rounded-full bg-foreground py-1.5 pl-5 pr-1.5 text-sm font-semibold text-background no-underline shadow-[0_18px_38px_rgba(0,0,0,0.18)] transition-transform duration-500 ease-[cubic-bezier(0.32,0.72,0,1)] hover:scale-[1.015] active:scale-[0.985]"
+                  href="/resume"
+                  render={(props) => {
+                    const anchorProps = {
+                      ...(props as ComponentPropsWithRef<"a">),
+                    };
+
+                    delete anchorProps.href;
+
+                    return <RouterLink {...anchorProps} to="/resume" />;
+                  }}
+                >
+                  View Resume
+                  <span className="flex size-9 items-center justify-center rounded-full bg-background/12 text-background transition-transform duration-500 ease-[cubic-bezier(0.32,0.72,0,1)] group-hover:translate-x-1 group-hover:-translate-y-0.5">
+                    <ArrowRightIcon size={17} />
+                  </span>
+                </Link>
+              )}
+              <Link
+                className="group inline-flex min-h-12 items-center gap-3 rounded-full border border-border/80 bg-surface/70 px-5 text-sm font-semibold text-foreground no-underline transition-[background-color,border-color,transform] duration-500 ease-[cubic-bezier(0.32,0.72,0,1)] hover:scale-[1.015] hover:border-accent/45 hover:bg-surface active:scale-[0.985]"
+                href={siteConfig.links.github}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <GitHubIcon size={18} />
+                GitHub
+                <ArrowUpRightIcon
+                  className="transition-transform duration-500 ease-[cubic-bezier(0.32,0.72,0,1)] group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+                  size={16}
+                />
+              </Link>
+            </div>
+
+            <div className="mt-14 grid max-w-3xl grid-cols-1 gap-3 sm:grid-cols-3">
+              {impactItems.map((item) => (
+                <div
+                  key={item.label}
+                  className="rounded-2xl border border-border/70 bg-surface/55 p-4 shadow-[0_1px_0_rgba(255,255,255,0.08)_inset]"
+                >
+                  <div className="font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted">
+                    {item.label}
+                  </div>
+                  <div className="mt-2 text-xl font-semibold text-foreground">
+                    {item.value}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </m.div>
+
+          <m.aside
+            className="rounded-[2rem] border border-border/70 bg-default/45 p-2 shadow-[var(--surface-shadow)]"
+            variants={{
+              hidden: { opacity: 0, y: 34 },
+              visible: {
+                opacity: 1,
+                y: 0,
+                transition: { duration: 0.85, ease: [0.32, 0.72, 0, 1] },
+              },
+            }}
+          >
+            <div className="rounded-[1.5rem] border border-border/65 bg-surface/82 p-5 sm:p-6">
+              <div className="flex items-start justify-between gap-6">
+                <div>
+                  <Typography
+                    className="font-mono text-[11px] font-medium uppercase tracking-[0.16em] text-muted"
+                    type="body-xs"
+                  >
+                    Current focus
+                  </Typography>
+                  <Typography.Heading
+                    className="mt-3 text-2xl font-semibold tracking-normal text-foreground"
+                    level={2}
+                  >
+                    {siteConfig.profile.role}
+                  </Typography.Heading>
+                </div>
+                <div className="rounded-full border border-accent/30 bg-accent/12 px-3 py-1 font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-foreground">
+                  Open CV
+                </div>
+              </div>
+
+              <div className="mt-8 space-y-4">
+                {focusItems.map((item) => {
+                  const Icon = item.icon;
+
+                  return (
+                    <div
+                      key={item.label}
+                      className="grid grid-cols-[2.5rem_1fr] gap-4 border-t border-border/70 pt-4"
+                    >
+                      <div className="flex size-10 items-center justify-center rounded-xl bg-default text-foreground">
+                        <Icon size={18} />
+                      </div>
+                      <div>
+                        <div className="text-sm font-semibold text-foreground">
+                          {item.label}
+                        </div>
+                        <div className="mt-1 text-sm leading-6 text-muted">
+                          {item.detail}
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+
+              <div className="mt-8 flex flex-wrap gap-2">
+                {siteConfig.profile.focusAreas.map((item) => (
+                  <span
+                    key={item}
+                    className="rounded-full border border-border/70 bg-default/70 px-3 py-1.5 text-xs font-medium text-muted"
+                  >
+                    {item}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </m.aside>
+        </m.div>
       </section>
     </DefaultLayout>
   );

--- a/src/pages/resume.tsx
+++ b/src/pages/resume.tsx
@@ -40,14 +40,20 @@ function useResumeData(): ResumeState {
 
 function ResumeLoadingSkeleton() {
   return (
-    <div className="mx-auto max-w-4xl px-6 pb-24 pt-32 sm:pt-40">
-      <Skeleton className="h-6 w-44 rounded-full" />
-      <Skeleton className="mt-8 h-14 w-2/3 rounded-lg" />
-      <Skeleton className="mt-4 h-6 w-1/2 rounded-lg" />
-      <div className="mt-12 space-y-3">
-        <Skeleton className="h-4 w-full rounded-lg" />
-        <Skeleton className="h-4 w-5/6 rounded-lg" />
-        <Skeleton className="h-4 w-4/6 rounded-lg" />
+    <div className="mx-auto grid w-full max-w-7xl grid-cols-1 gap-10 px-4 pb-24 pt-28 sm:px-6 sm:pt-36 lg:grid-cols-[minmax(270px,340px)_minmax(0,1fr)] lg:gap-12">
+      <div className="rounded-[2rem] border border-border/70 bg-default/45 p-2">
+        <div className="rounded-[1.5rem] border border-border/65 bg-surface/80 p-6">
+          <Skeleton className="h-6 w-36 rounded-full" />
+          <Skeleton className="mt-10 h-12 w-4/5 rounded-lg" />
+          <Skeleton className="mt-4 h-5 w-2/3 rounded-lg" />
+          <Skeleton className="mt-8 h-12 w-full rounded-full" />
+        </div>
+      </div>
+      <div className="space-y-5">
+        <Skeleton className="h-6 w-44 rounded-full" />
+        <Skeleton className="h-36 w-full rounded-2xl" />
+        <Skeleton className="h-36 w-full rounded-2xl" />
+        <Skeleton className="h-36 w-full rounded-2xl" />
       </div>
     </div>
   );
@@ -61,7 +67,7 @@ export default function ResumePage() {
       {resume.status === "loading" ? (
         <ResumeLoadingSkeleton />
       ) : resume.status === "error" ? (
-        <div className="mx-auto max-w-2xl px-6 pb-24 pt-40">
+        <div className="mx-auto max-w-2xl px-4 pb-24 pt-36 sm:px-6 sm:pt-40">
           <Alert status="danger">
             <Alert.Indicator />
             <Alert.Content>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,2 +1,141 @@
 @import "tailwindcss";
 @import "@heroui/styles";
+
+@theme {
+  --font-sans: "Geist Variable", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "Geist Mono Variable", ui-monospace, SFMono-Regular, monospace;
+}
+
+:root,
+[data-theme="light"] {
+  --radius: 0.5rem;
+  --background: oklch(0.972 0.003 247);
+  --foreground: oklch(0.22 0.015 250);
+  --surface: oklch(0.995 0.001 247);
+  --surface-secondary: oklch(0.946 0.006 247);
+  --surface-tertiary: oklch(0.914 0.01 247);
+  --overlay: oklch(0.995 0.001 247);
+  --muted: oklch(0.49 0.018 250);
+  --default: oklch(0.925 0.006 247);
+  --border: oklch(0.86 0.009 247);
+  --separator: oklch(0.89 0.007 247);
+  --accent: oklch(0.68 0.17 155);
+  --accent-foreground: oklch(0.16 0.02 160);
+  --success: oklch(0.68 0.17 155);
+  --success-foreground: oklch(0.16 0.02 160);
+  --focus: var(--accent);
+  --link: var(--foreground);
+  --surface-shadow:
+    0 18px 46px rgba(22, 31, 43, 0.08), 0 1px 0 rgba(255, 255, 255, 0.85) inset;
+  --resume-grid: color-mix(in oklab, var(--foreground) 7%, transparent);
+  --resume-wash: color-mix(in oklab, var(--accent) 9%, transparent);
+}
+
+[data-theme="dark"] {
+  --background: oklch(0.15 0.014 250);
+  --foreground: oklch(0.965 0.004 247);
+  --surface: oklch(0.2 0.018 250);
+  --surface-secondary: oklch(0.245 0.018 250);
+  --surface-tertiary: oklch(0.29 0.017 250);
+  --overlay: oklch(0.22 0.018 250);
+  --muted: oklch(0.72 0.018 247);
+  --default: oklch(0.28 0.017 250);
+  --border: oklch(0.31 0.018 250);
+  --separator: oklch(0.27 0.017 250);
+  --accent: oklch(0.76 0.17 155);
+  --accent-foreground: oklch(0.16 0.02 160);
+  --success: oklch(0.76 0.17 155);
+  --success-foreground: oklch(0.16 0.02 160);
+  --focus: var(--accent);
+  --link: var(--foreground);
+  --surface-shadow:
+    0 22px 55px rgba(0, 0, 0, 0.32), 0 1px 0 rgba(255, 255, 255, 0.06) inset;
+  --resume-grid: color-mix(in oklab, var(--foreground) 8%, transparent);
+  --resume-wash: color-mix(in oklab, var(--accent) 11%, transparent);
+}
+
+html {
+  min-width: 320px;
+  scroll-behavior: smooth;
+  background: var(--background);
+}
+
+body {
+  min-width: 320px;
+  min-height: 100dvh;
+  margin: 0;
+  background: var(--background);
+  color: var(--foreground);
+  font-family: var(--font-sans);
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+#root {
+  min-height: 100dvh;
+}
+
+::selection {
+  background: color-mix(in oklab, var(--accent) 32%, transparent);
+  color: var(--foreground);
+}
+
+.premium-shell {
+  isolation: isolate;
+  overflow-x: clip;
+}
+
+.premium-shell::before {
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  pointer-events: none;
+  content: "";
+  background:
+    linear-gradient(
+      115deg,
+      transparent 0%,
+      var(--resume-wash) 42%,
+      transparent 68%
+    ),
+    linear-gradient(var(--resume-grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--resume-grid) 1px, transparent 1px);
+  background-size:
+    100% 100%,
+    44px 44px,
+    44px 44px;
+  mask-image: linear-gradient(to bottom, black 0%, black 62%, transparent 100%);
+}
+
+.premium-shell::after {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  content: "";
+  background:
+    linear-gradient(to bottom, transparent 0%, var(--background) 82%),
+    linear-gradient(
+      90deg,
+      var(--background) 0%,
+      transparent 26%,
+      transparent 74%,
+      var(--background) 100%
+    );
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/src/utils/animations.ts
+++ b/src/utils/animations.ts
@@ -1,7 +1,4 @@
-/**
- * Common animation variants for framer-motion
- * Centralized to avoid duplication across components
- */
+const premiumEase = [0.32, 0.72, 0, 1] as const;
 
 export const fadeInStagger = {
   container: {
@@ -9,17 +6,18 @@ export const fadeInStagger = {
     visible: {
       opacity: 1,
       transition: {
-        staggerChildren: 0.1,
+        staggerChildren: 0.08,
       },
     },
   },
   item: {
-    hidden: { opacity: 0, y: 20 },
+    hidden: { opacity: 0, y: 28 },
     visible: {
       opacity: 1,
       y: 0,
       transition: {
-        duration: 0.5,
+        duration: 0.7,
+        ease: premiumEase,
       },
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -413,6 +413,16 @@
     "@eslint/core" "^0.17.0"
     levn "^0.4.1"
 
+"@fontsource-variable/geist-mono@^5.2.8":
+  version "5.2.8"
+  resolved "https://registry.yarnpkg.com/@fontsource-variable/geist-mono/-/geist-mono-5.2.8.tgz#b71fbb9d8332dde974adeba3dbe5180c4ce9e9aa"
+  integrity sha512-KI5bj+hkkRiHttYHmccotUZ80ZuZyai+RwI1d7UId0clkx/jXxlo8qYK8j54WzmpBjtMoEMPyllV7faDcj+6RA==
+
+"@fontsource-variable/geist@^5.2.9":
+  version "5.2.9"
+  resolved "https://registry.yarnpkg.com/@fontsource-variable/geist/-/geist-5.2.9.tgz#261356515cb97e51bee31991259776b7435f0bd8"
+  integrity sha512-TP+QSBG3wxKGPE33CbMy/L0Nu3qvJ6Fy81Yc4LnQ95xH+i+cfEp8fyU8/kfV14YwszxIFPhnoMTbjL71waVpyQ==
+
 "@formatjs/ecma402-abstract@2.3.6":
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz#d6ca9d3579054fe1e1a0a0b5e872e0d64922e4e1"
@@ -593,6 +603,11 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@phosphor-icons/react@^2.1.10":
+  version "2.1.10"
+  resolved "https://registry.yarnpkg.com/@phosphor-icons/react/-/react-2.1.10.tgz#3a97ec5b7a4b8d53afeb29125bc17e74ed2daf92"
+  integrity sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==
 
 "@pkgr/core@^0.1.0":
   version "0.1.2"


### PR DESCRIPTION
## Summary
- Redesign the home and resume pages with a premium systems visual direction.
- Add self-hosted Geist fonts and Phosphor icons.
- Refresh resume layout, section hierarchy, action links, and scanner-friendly item rows.
- Add WebGL capability handling for the Threads background so unsupported environments do not crash the page.

## Verification
- yarn run check
- yarn build
- Headless Chrome screenshots for / and /resume at desktop and mobile sizes
- HTTP smoke checks for /, /resume, /resume.yaml, and /resume.pdf