### PR TITLE
feat(ui): liquid glass redesign

### DIFF
--- a/src/components/ResumeContent.tsx
+++ b/src/components/ResumeContent.tsx
@@ -18,18 +18,19 @@ export const ResumeContent = ({ data }: ResumeContentProps) => {
         <ResumeHeader cv={cv} languages={languages} />
       </div>
 
-      <div className="reveal-stagger space-y-20 md:space-y-24">
+      <div className="reveal-stagger space-y-6 md:space-y-8">
         {data.sectionOrder.map((sectionName) => {
           if (languages && sectionName === languages.key) {
             return null;
           }
 
           return (
-            <ResumeSectionRenderer
-              key={sectionName}
-              entries={cv.sections[sectionName]}
-              sectionName={sectionName}
-            />
+            <div key={sectionName}>
+              <ResumeSectionRenderer
+                entries={cv.sections[sectionName]}
+                sectionName={sectionName}
+              />
+            </div>
           );
         })}
       </div>

--- a/src/components/ResumeHeader.tsx
+++ b/src/components/ResumeHeader.tsx
@@ -48,11 +48,11 @@ export function ResumeHeader({ cv, languages }: ResumeHeaderProps) {
   const pdfPath = resolveAssetPath(env.RESUME_PDF_PATH);
 
   return (
-    <header className="mb-16 border-b border-border pb-14 md:mb-20 md:pb-20">
+    <header className="glass-panel mb-6 p-6 md:mb-8 md:p-10">
       <div className="grid grid-cols-1 gap-8 md:grid-cols-[1fr_auto] md:items-start md:gap-10">
         <div className="order-2 md:order-1">
           <div className="mb-8">
-            <Chip size="sm" variant="soft">
+            <Chip className="glass-chip" size="sm" variant="soft">
               <span className="size-1.5 rounded-full bg-success" />
               <Chip.Label className="font-mono text-[0.7rem] tracking-wide">
                 PROFILE · {formatUpdatedAt()}
@@ -118,7 +118,7 @@ export function ResumeHeader({ cv, languages }: ResumeHeaderProps) {
 
         {cv.photo && (
           <div className="order-1 flex justify-start md:order-2 md:justify-end">
-            <Avatar className="size-24 ring-1 ring-border md:size-32">
+            <Avatar className="size-24 ring-1 ring-[color:var(--glass-border)] md:size-32">
               <Avatar.Image alt={cv.name} src={cv.photo} />
               <Avatar.Fallback>{initials(cv.name)}</Avatar.Fallback>
             </Avatar>
@@ -138,6 +138,7 @@ export function ResumeHeader({ cv, languages }: ResumeHeaderProps) {
             {languages.entries.map((lang, index) => (
               <Chip
                 key={`lang-${index}-${lang.label}`}
+                className="glass-chip"
                 size="sm"
                 variant="soft"
               >

--- a/src/components/ResumeSections/NormalSection.tsx
+++ b/src/components/ResumeSections/NormalSection.tsx
@@ -82,7 +82,7 @@ export const NormalSection: FC<NormalSectionProps> = ({
                   {entry.keywords.map((keyword) => (
                     <Chip
                       key={keyword}
-                      className="font-mono tracking-tight"
+                      className="glass-chip font-mono tracking-tight"
                       size="sm"
                       variant="soft"
                     >

--- a/src/components/ResumeSections/OneLineSection.tsx
+++ b/src/components/ResumeSections/OneLineSection.tsx
@@ -55,7 +55,7 @@ export const OneLineSection: FC<OneLineSectionProps> = ({
                   {entry.keywords.map((keyword) => (
                     <Chip
                       key={keyword}
-                      className="font-mono tracking-tight"
+                      className="glass-chip font-mono tracking-tight"
                       size="sm"
                       variant="soft"
                     >

--- a/src/components/ResumeSections/SectionCard.tsx
+++ b/src/components/ResumeSections/SectionCard.tsx
@@ -2,18 +2,22 @@ import type { FC, ReactNode } from "react";
 
 import { Separator, Typography } from "@heroui/react";
 
+import { useGlassPointer } from "@/hooks/useGlassPointer";
+
 interface SectionCardProps {
   title: string;
   children: ReactNode;
 }
 
 /**
- * Section wrapper: an uppercase heading (HeroUI Typography rendered as h2)
- * followed by a full-width HeroUI Separator, then content.
+ * Section wrapper: a frosted glass panel with an uppercase heading (HeroUI
+ * Typography rendered as h2), a full-width HeroUI Separator, then content.
  */
 export const SectionCard: FC<SectionCardProps> = ({ title, children }) => {
+  const glassRef = useGlassPointer();
+
   return (
-    <section className="scroll-mt-24">
+    <section ref={glassRef} className="glass-panel scroll-mt-24 p-6 md:p-8">
       <div className="mb-8 flex items-center gap-4">
         <Typography.Heading
           className="font-mono text-xs font-medium uppercase leading-4 tracking-[0.15em] text-muted"

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -80,8 +80,10 @@ export const Navbar = () => {
     <header className="pointer-events-none fixed inset-x-0 top-0 z-50 flex justify-center px-4 pt-4 sm:pt-5">
       <nav
         className={cn(
-          "pointer-events-auto flex items-center gap-1 rounded-full border border-border bg-surface/70 backdrop-blur-xl transition-[box-shadow,padding] duration-300",
-          isScrolled ? "py-1 shadow-lg" : "py-1.5 shadow-none",
+          "glass-edge pointer-events-auto flex items-center gap-1 rounded-full border border-[color:var(--glass-border)] bg-[var(--glass-bg)] backdrop-blur-[16px] backdrop-saturate-[1.4] transition-[box-shadow,padding] duration-300",
+          isScrolled
+            ? "py-1 shadow-[inset_0_1px_0_0_var(--glass-highlight),0_10px_30px_-10px_rgba(0,0,0,0.35)]"
+            : "py-1.5 shadow-[inset_0_1px_0_0_var(--glass-highlight)]",
         )}
       >
         <div ref={listRef} className="relative flex items-center gap-0.5 pl-1">

--- a/src/components/shared/ItemCard.tsx
+++ b/src/components/shared/ItemCard.tsx
@@ -14,7 +14,7 @@ interface ItemCardProps {
 export const ItemCard: FC<ItemCardProps> = ({ children, className = "" }) => (
   <div
     className={cn(
-      "group -mx-4 rounded-lg px-4 py-6 transition-colors duration-200 hover:bg-default/30",
+      "group -mx-6 rounded-xl px-6 py-6 transition-[transform,background-color] duration-200 ease-[var(--ease-out-fluid)] hover:-translate-y-px hover:bg-[var(--glass-hover-bg)] active:translate-y-0 active:scale-[0.995] md:-mx-8 md:px-8",
       className,
     )}
   >

--- a/src/hooks/useGlassPointer.ts
+++ b/src/hooks/useGlassPointer.ts
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Drives a pointer-tracked specular sheen on a glass surface. Returns a ref to
+ * attach to the target element; on pointer move it writes `--glass-mx` /
+ * `--glass-my` (0-100%) and `--glass-active` (0-1) as CSS custom properties,
+ * rAF-throttled, so the CSS radial highlight + spectral rim follow the cursor
+ * 1:1. No-op on touch pointers and under prefers-reduced-motion (no listeners,
+ * no rAF, no writes).
+ */
+export function useGlassPointer<T extends HTMLElement = HTMLElement>() {
+  const ref = useRef<T>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+
+    if (!el) return;
+
+    const noHover = window.matchMedia("(hover: none)").matches;
+    const reduced = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+
+    if (noHover || reduced) return;
+
+    let frame = 0;
+    let px = 50;
+    let py = 50;
+    let active = 0;
+
+    const paint = () => {
+      frame = 0;
+      el.style.setProperty("--glass-mx", `${px}%`);
+      el.style.setProperty("--glass-my", `${py}%`);
+      el.style.setProperty("--glass-active", `${active}`);
+    };
+
+    const schedule = () => {
+      if (frame) return;
+
+      frame = requestAnimationFrame(paint);
+    };
+
+    const handleMove = (event: PointerEvent) => {
+      const rect = el.getBoundingClientRect();
+
+      px = ((event.clientX - rect.left) / rect.width) * 100;
+      py = ((event.clientY - rect.top) / rect.height) * 100;
+      active = 1;
+      schedule();
+    };
+
+    const handleLeave = () => {
+      if (frame) {
+        cancelAnimationFrame(frame);
+        frame = 0;
+      }
+
+      active = 0;
+      el.style.setProperty("--glass-active", "0");
+    };
+
+    el.addEventListener("pointerenter", handleMove);
+    el.addEventListener("pointerdown", handleMove);
+    el.addEventListener("pointermove", handleMove);
+    el.addEventListener("pointerleave", handleLeave);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      el.removeEventListener("pointerenter", handleMove);
+      el.removeEventListener("pointerdown", handleMove);
+      el.removeEventListener("pointermove", handleMove);
+      el.removeEventListener("pointerleave", handleLeave);
+    };
+  }, []);
+
+  return ref;
+}

--- a/src/layouts/default.tsx
+++ b/src/layouts/default.tsx
@@ -1,12 +1,17 @@
 import type { ReactNode } from "react";
 
+import { useLocation } from "react-router-dom";
+
 import { Navbar } from "@/components/navbar";
 
 export default function DefaultLayout({ children }: { children: ReactNode }) {
+  const { pathname } = useLocation();
+
   return (
-    <div className="relative flex min-h-screen flex-col bg-background text-foreground">
+    <div className="relative isolate flex min-h-screen flex-col bg-background text-foreground">
+      {pathname !== "/" && <div aria-hidden="true" className="ambient-field" />}
       <Navbar />
-      <main className="flex-grow">{children}</main>
+      <main className="relative z-0 flex-grow">{children}</main>
     </div>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -87,7 +87,7 @@ export default function IndexPage() {
           <div className="flex flex-wrap items-center gap-3">
             {resumeAvailable && (
               <Link
-                className="button button--primary gap-2"
+                className="button button--primary glass-cta-sheen glass-edge gap-2"
                 href="/resume"
                 render={(props) => {
                   // Drop the placeholder href so RouterLink fully owns the
@@ -106,7 +106,7 @@ export default function IndexPage() {
               </Link>
             )}
             <Link
-              className="button button--outline gap-2"
+              className="button glass-cta gap-2"
               href={siteConfig.links.github}
               rel="noopener noreferrer"
               target="_blank"

--- a/src/pages/resume.tsx
+++ b/src/pages/resume.tsx
@@ -41,23 +41,27 @@ function useResumeData(): ResumeState {
 function ResumeLoadingSkeleton() {
   return (
     <div className="mx-auto max-w-4xl px-6 pb-24 pt-32 sm:pt-40">
-      <Skeleton className="h-6 w-44 rounded-full" />
-      <Skeleton className="mt-8 h-14 w-2/3 rounded-lg" />
-      <Skeleton className="mt-4 h-6 w-1/2 rounded-lg" />
-      <Skeleton className="mt-6 h-4 w-64 rounded-lg" />
-      <div className="mt-8 flex gap-5">
-        <Skeleton className="h-4 w-20 rounded-lg" />
-        <Skeleton className="h-4 w-20 rounded-lg" />
-        <Skeleton className="h-4 w-28 rounded-lg" />
+      <div className="glass-panel mb-6 p-6 md:mb-8 md:p-10">
+        <Skeleton className="h-6 w-44 rounded-full" />
+        <Skeleton className="mt-8 h-14 w-2/3 rounded-lg" />
+        <Skeleton className="mt-4 h-6 w-1/2 rounded-lg" />
+        <Skeleton className="mt-6 h-4 w-64 rounded-lg" />
+        <div className="mt-8 flex gap-5">
+          <Skeleton className="h-4 w-20 rounded-lg" />
+          <Skeleton className="h-4 w-20 rounded-lg" />
+          <Skeleton className="h-4 w-28 rounded-lg" />
+        </div>
       </div>
-      <div className="mt-16 flex items-center gap-4">
-        <Skeleton className="h-3 w-32 rounded-lg" />
-        <Skeleton className="h-px flex-1" />
-      </div>
-      <div className="mt-8 space-y-3">
-        <Skeleton className="h-4 w-full rounded-lg" />
-        <Skeleton className="h-4 w-5/6 rounded-lg" />
-        <Skeleton className="h-4 w-4/6 rounded-lg" />
+      <div className="glass-panel p-6 md:p-8">
+        <div className="flex items-center gap-4">
+          <Skeleton className="h-3 w-32 rounded-lg" />
+          <Skeleton className="h-px flex-1" />
+        </div>
+        <div className="mt-8 space-y-3">
+          <Skeleton className="h-4 w-full rounded-lg" />
+          <Skeleton className="h-4 w-5/6 rounded-lg" />
+          <Skeleton className="h-4 w-4/6 rounded-lg" />
+        </div>
       </div>
     </div>
   );
@@ -80,7 +84,7 @@ export default function ResumePage() {
             </Alert.Content>
           </Alert>
 
-          <Card className="mt-6 w-full">
+          <Card className="glass-panel mt-6 w-full">
             <Card.Header>
               <Card.Title>Check VITE_RESUME_FILE</Card.Title>
               <Card.Description>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -12,6 +12,21 @@
 }
 
 @layer base {
+  /* Liquid-glass tokens shared by both themes. */
+  :root {
+    --glass-radius: 1.25rem;
+    --glass-blur: 16px;
+    --glass-saturate: 140%;
+    --glass-spectral: linear-gradient(
+      125deg,
+      oklch(0.85 0.13 205 / 0.55) 0%,
+      oklch(0.85 0.13 205 / 0) 34%,
+      oklch(0.72 0.16 292 / 0) 66%,
+      oklch(0.72 0.16 292 / 0.55) 100%
+    );
+    --glass-spectral-opacity-hover: 0.6;
+  }
+
   /* Cool-tinted light theme; surface stays white so the navbar pill lifts off the page. */
   :root,
   .light,
@@ -19,6 +34,35 @@
   [data-theme="light"],
   [data-theme="default"] {
     --background: oklch(0.985 0.002 240);
+
+    --glass-bg: oklch(0.99 0.002 240 / 0.7);
+    --glass-bg-hover: oklch(1 0 0 / 0.82);
+    --glass-border: oklch(0.9 0.004 240 / 0.8);
+    --glass-highlight: rgba(255, 255, 255, 0.7);
+    --glass-hover-bg: oklch(0.94 0.004 240 / 0.55);
+    --glass-chip-bg: oklch(0.965 0.003 240 / 0.85);
+    --glass-chip-border: oklch(0.86 0.005 240 / 0.7);
+    --glass-shadow:
+      0 1px 2px 0 rgba(16, 24, 40, 0.04),
+      0 12px 28px -8px rgba(16, 24, 40, 0.12),
+      inset 0 1px 0 0 var(--glass-highlight);
+    --glass-spectral-opacity: 0.24;
+    --ambient-mesh:
+      radial-gradient(
+        60% 50% at 15% 10%,
+        oklch(0.7 0.09 220 / 0.06),
+        transparent 60%
+      ),
+      radial-gradient(
+        55% 45% at 88% 28%,
+        oklch(0.7 0.1 290 / 0.05),
+        transparent 60%
+      ),
+      radial-gradient(
+        75% 60% at 50% 106%,
+        oklch(0.8 0.05 235 / 0.05),
+        transparent 60%
+      );
   }
 
   /* OLED blue-black dark theme tuned to the Threads hero; matches the meta theme-color. */
@@ -28,15 +72,179 @@
     --surface: oklch(0.21 0.012 235);
     --border: oklch(0.26 0.01 235);
     --separator: oklch(0.23 0.01 235);
+
+    --glass-bg: oklch(0.225 0.014 235 / 0.62);
+    --glass-bg-hover: oklch(0.255 0.016 235 / 0.72);
+    --glass-border: oklch(0.34 0.012 235 / 0.55);
+    --glass-highlight: rgba(255, 255, 255, 0.07);
+    --glass-hover-bg: oklch(0.26 0.016 235 / 0.5);
+    --glass-chip-bg: oklch(0.27 0.012 235 / 0.75);
+    --glass-chip-border: oklch(0.37 0.01 235 / 0.5);
+    --glass-shadow:
+      inset 0 1px 0 0 var(--glass-highlight),
+      inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+    --glass-spectral-opacity: 0.32;
+    --ambient-mesh:
+      radial-gradient(
+        60% 50% at 18% 12%,
+        oklch(0.62 0.14 220 / 0.1),
+        transparent 60%
+      ),
+      radial-gradient(
+        55% 45% at 85% 30%,
+        oklch(0.55 0.16 290 / 0.08),
+        transparent 60%
+      ),
+      radial-gradient(
+        72% 60% at 50% 108%,
+        oklch(0.5 0.1 235 / 0.1),
+        transparent 60%
+      );
   }
 }
 
-/* On-mount entrance: fade in while rising. Replaces the former framer-motion
-   stagger on the resume page. */
-@keyframes fade-rise {
+@layer components {
+  /* Frosted glass panel: the single glass layer in any stack. Dark leans on
+     border + inset highlight + blur (no drop shadow); light adds a soft one. */
+  .glass-panel {
+    position: relative;
+    isolation: isolate;
+    border-radius: var(--glass-radius);
+    border: 1px solid var(--glass-border);
+    background-color: var(--glass-bg);
+    box-shadow: var(--glass-shadow);
+    -webkit-backdrop-filter: blur(var(--glass-blur))
+      saturate(var(--glass-saturate));
+    backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+    --glass-mx: 50%;
+    --glass-my: 50%;
+    --glass-active: 0;
+    transition:
+      transform 200ms var(--ease-out-fluid),
+      box-shadow 200ms var(--ease-out-fluid),
+      border-color 200ms var(--ease-out-fluid);
+  }
+
+  /* Lift real content above the specular sheen for legibility. */
+  .glass-panel > * {
+    position: relative;
+    z-index: 1;
+  }
+
+  /* Pointer-tracked specular catch-light (sits on the frost, under the text). */
+  .glass-panel::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    opacity: var(--glass-active);
+    transition: opacity 260ms var(--ease-out-fluid);
+    background: radial-gradient(
+      18rem 18rem at var(--glass-mx) var(--glass-my),
+      oklch(1 0 0 / 0.22),
+      transparent 60%
+    );
+    mix-blend-mode: screen;
+  }
+
+  /* Faint cyan->violet spectral rim, painted only on the 1px perimeter. */
+  .glass-panel::after,
+  .glass-edge::after,
+  .glass-cta::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 2;
+    border-radius: inherit;
+    padding: 1px;
+    pointer-events: none;
+    background: var(--glass-spectral);
+    opacity: var(--glass-spectral-opacity);
+    transition: opacity 300ms var(--ease-out-fluid);
+    -webkit-mask:
+      linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask:
+      linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
+    mask-composite: exclude;
+  }
+
+  .glass-panel:hover::after,
+  .glass-edge:hover::after,
+  .glass-cta:hover::after {
+    opacity: var(--glass-spectral-opacity-hover);
+  }
+
+  /* Hover lift + press. Spring feel via HeroUI's fluid easing, no motion lib. */
+  @media (hover: hover) {
+    .glass-panel:hover {
+      transform: translateY(-2px);
+      will-change: transform;
+      box-shadow:
+        var(--glass-shadow),
+        0 10px 34px -14px oklch(0 0 0 / 0.5);
+    }
+  }
+
+  .glass-panel:active {
+    transform: translateY(-1px) scale(0.99);
+    transition-duration: 120ms;
+  }
+
+  /* Frosted button: overrides HeroUI .button's bg vars, keeps its press-scale. */
+  .glass-cta {
+    --button-bg: var(--glass-bg);
+    --button-bg-hover: var(--glass-bg-hover);
+    --button-bg-pressed: var(--glass-bg-hover);
+    --button-fg: var(--foreground);
+    position: relative;
+    border: 1px solid var(--glass-border);
+    box-shadow: var(--glass-shadow);
+    -webkit-backdrop-filter: blur(var(--glass-blur))
+      saturate(var(--glass-saturate));
+    backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  }
+
+  /* Top-edge specular highlight for the solid accent primary CTA. */
+  .glass-cta-sheen {
+    box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.28);
+  }
+
+  .glass-edge {
+    position: relative;
+  }
+
+  /* Solid chip backing over glass (no backdrop-filter -> no blur-on-blur).
+     .chip.glass-chip ties .chip--default.chip--soft and wins on source order. */
+  .chip.glass-chip {
+    --chip-bg: var(--glass-chip-bg);
+    border: 1px solid var(--glass-chip-border);
+  }
+
+  /* Shared ambient field behind resume content; the glass refracts it. */
+  .ambient-field {
+    position: fixed;
+    inset: 0;
+    z-index: -10;
+    pointer-events: none;
+    background-image: var(--ambient-mesh);
+    background-repeat: no-repeat;
+    will-change: transform;
+    animation: ambient-drift 100s linear infinite;
+  }
+}
+
+/* On-mount entrance: glass materializing (rise + scale resolving), not a plain
+   fade. Applied to wrappers, never to the glass panels themselves, so an
+   animated transform never collides with a panel's backdrop-filter. */
+@keyframes materialize {
   from {
     opacity: 0;
-    transform: translateY(20px);
+    transform: translateY(16px) scale(0.985);
   }
   to {
     opacity: 1;
@@ -44,9 +252,22 @@
   }
 }
 
+/* Imperceptibly slow drift for the ambient field (~0.01Hz, returns to start). */
+@keyframes ambient-drift {
+  0% {
+    transform: translate3d(-1.5%, -1%, 0) scale(1.06);
+  }
+  50% {
+    transform: translate3d(1.5%, 1.5%, 0) scale(1.12);
+  }
+  100% {
+    transform: translate3d(-1.5%, -1%, 0) scale(1.06);
+  }
+}
+
 .reveal-on-load,
 .reveal-stagger > * {
-  animation: fade-rise 0.5s ease both;
+  animation: materialize 0.55s var(--ease-out-fluid) both;
 }
 
 /* Stagger each direct child of a .reveal-stagger container. */
@@ -81,9 +302,62 @@
   animation-delay: 1s;
 }
 
+/* Reduced motion: no move/scale/drift/sheen; content simply appears. */
 @media (prefers-reduced-motion: reduce) {
   .reveal-on-load,
   .reveal-stagger > * {
     animation: none;
+  }
+
+  .glass-panel,
+  .glass-panel::before,
+  .glass-panel::after {
+    transition: none;
+  }
+
+  .glass-panel:hover,
+  .glass-panel:active {
+    transform: none;
+  }
+
+  .ambient-field {
+    animation: none;
+  }
+}
+
+/* Reduced transparency: frostier/solid glass, no blur, no decorative sheen. */
+@media (prefers-reduced-transparency: reduce) {
+  .glass-panel,
+  .glass-cta {
+    background-color: var(--surface);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
+
+  .glass-panel::before,
+  .glass-panel::after,
+  .glass-cta::after {
+    display: none;
+  }
+
+  .ambient-field {
+    opacity: 0;
+  }
+}
+
+/* More contrast: near-solid panels with a defined, contrasting border. */
+@media (prefers-contrast: more) {
+  .glass-panel,
+  .glass-cta {
+    background-color: var(--surface);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+    border: 1px solid var(--foreground);
+  }
+
+  .glass-panel::before,
+  .glass-panel::after,
+  .glass-cta::after {
+    display: none;
   }
 }


### PR DESCRIPTION
## Summary

Redesigns the site around an Apple "Liquid Glass" aesthetic while keeping the existing editorial, mono-for-meta identity and legibility. Resume sections become frosted glass panels floating over a subtle ambient field, with light-catching edges as the signature detail.

The direction is grounded in the subject (firmware / secure-boot engineer): a deep OLED-blue field with cool, near-neutral glass and only a whisper of cyan-to-violet spectral refraction at the rims. Content is never stacked translucent-on-translucent, and dense text stays crisp.

## What changed

- **Glass material system** (`src/styles/globals.css`): a CSS-first `.glass-panel` / `.glass-cta` / `.glass-chip` set built on new per-theme tokens (`--glass-bg`, `--glass-border`, `--glass-highlight`, `--glass-blur`, ...). Dark leans on border + inset highlight + blur (no drop shadow); light adds a soft drop shadow.
- **Signature interaction** (`src/hooks/useGlassPointer.ts`): a lightweight, rAF-throttled hook that writes CSS custom properties so a specular sheen tracks the pointer 1:1 across each panel. No new animation library. No-op on touch and under reduced motion.
- **Motion**: the on-mount reveal becomes a "materialize" (rise + scale), applied to wrappers so an animated transform never collides with a panel's `backdrop-filter`. A very slow ambient drift sits behind resume content.
- **Surfaces**: navbar, resume header, every section, keyword/language chips, hero CTAs, and the loading/error states adopt the material.
- **Accessibility**: full fallbacks for `prefers-reduced-motion`, `prefers-reduced-transparency`, and `prefers-contrast: more` (near-solid panels with a defined border).

## Notes

- No changes to `resume.yaml`, the PDF, `--background`, or the pre-paint theme script.
- No new runtime dependencies.

## Verification

- `yarn run check` (tsc + prettier + eslint) clean.
- `yarn build` passes.
- Visual QA via headless Chrome across light/dark, the pointer sheen, chips on glass, and the `prefers-contrast: more` fallback.
